### PR TITLE
Fix: webrtc-agent network_interfaces configuration invalid.

### DIFF
--- a/source/agent/workingNode.js
+++ b/source/agent/workingNode.js
@@ -141,7 +141,7 @@ function init_controller() {
                 return;
             }
 
-            controller.networkInterfaces = Array.isArray(nodeConfig.webrtc.network_interface) ? nodeConfig.webrtc.network_interface : [];
+            controller.networkInterfaces = Array.isArray(nodeConfig.webrtc.network_interfaces) ? nodeConfig.webrtc.network_interfaces : [];
             controller.clusterIP = clusterIP;
             controller.agentID = parentID;
             controller.networkInterfaces.forEach((i) => {


### PR DESCRIPTION
The network_interfaces configuration key in agent.tom does not match the code.