### PR TITLE
Fix: Invalid config webrtc.network_interface.replaced_ip_address.

### DIFF
--- a/source/agent/webrtc/configLoader.js
+++ b/source/agent/webrtc/configLoader.js
@@ -66,9 +66,6 @@ module.exports.load = () => {
         process.exit(1);
       }
       item.ip_address = addr.ip;
-      if (item.replaced_ip_address) {
-        item.private_ip_match_pattern = new RegExp(addr.ip, 'g');
-      }
     });
 
     return config;

--- a/source/agent/webrtc/wrtcConnection.js
+++ b/source/agent/webrtc/wrtcConnection.js
@@ -370,8 +370,8 @@ module.exports = function (spec, on_status, on_mediaUpdate) {
                 case CONN_SDP:
                 case CONN_GATHERED:
                     networkInterfaces.forEach((i) => {
-                        if (i.private_ip_match_pattern && i.replaced_ip_address) {
-                            message = message.replace(i.private_ip_match_pattern, i.replaced_ip_address);
+                        if (i.ip_address && i.replaced_ip_address) {
+                            message = message.replace(new RegExp(i.ip_address, 'g'), i.replaced_ip_address);
                         }
                     });
                     audio && (message = determineAudioFmt(message));
@@ -382,8 +382,8 @@ module.exports = function (spec, on_status, on_mediaUpdate) {
 
                 case CONN_CANDIDATE:
                     networkInterfaces.forEach((i) => {
-                        if (i.private_ip_match_pattern && i.replaced_ip_address) {
-                          message = message.replace(i.private_ip_match_pattern, i.replaced_ip_address);
+                        if (i.ip_address && i.replaced_ip_address) {
+                          message = message.replace(new RegExp(i.ip_address, 'g'), i.replaced_ip_address);
                         }
                       });
                     on_status({type: 'candidate', candidate: message});


### PR DESCRIPTION
JSON.stringify can not apply to RegExp object. So private_ip_match_pattern is lost when agent pass it to webrtc nodeManager. 

Fix solution is change the type of private_ip_match_pattern from RegExp to string.