### PR TITLE
Adding docker support for basic example

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,38 @@
+################################
+# OWT WebRTC server
+#
+# Base image Ubuntu 18.04
+
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MEDIA_SDK_VER=18.4.0
+
+# Update the system
+RUN apt update
+
+# Install utils
+RUN apt install -y ca-certificates git lsb-release mongodb nodejs npm sudo wget
+
+RUN npm install -g grunt-cli node-gyp
+
+# Keep proxy environment for sudo
+RUN bash -c "echo \"Defaults env_keep = \\\"http_proxy https_proxy no_proxy \\\"\" >> /etc/sudoers"
+
+# Install owt-client
+RUN git clone https://github.com/open-webrtc-toolkit/owt-client-javascript.git
+RUN cd owt-client-javascript/scripts && npm install && grunt
+
+RUN wget https://github.com/Intel-Media-SDK/MediaSDK/releases/download/intel-mediasdk-$MEDIA_SDK_VER/MediaStack.tar.gz -P /tmp
+RUN cd /tmp && tar -zxf MediaStack.tar.gz && cd MediaStack && ./install_media.sh
+RUN rm /tmp/MediaStack.tar.gz && rm -rf /tmp/MediaStack
+ENV MFX_HOME=/opt/intel/mediasdk
+
+RUN git clone https://github.com/open-webrtc-toolkit/owt-server.git
+WORKDIR /owt-server
+
+# This is needed to patch licode
+RUN  git config --global user.email "you@example.com" && \
+  git config --global user.name "Your Name"
+
+RUN ./scripts/installDepsUnattended.sh

--- a/docker/conference/Dockerfile-conference
+++ b/docker/conference/Dockerfile-conference
@@ -1,0 +1,13 @@
+################################
+# OWT WebRTC Conference Sample
+
+FROM owt-server:latest
+
+ENV CLIENT_SAMPLE_PATH=/owt-client-javascript/dist/samples/conference
+
+WORKDIR /owt-server
+
+RUN ./scripts/build.js -t all --check
+RUN ./scripts/pack.js -t all --install-module --sample-path $CLIENT_SAMPLE_PATH .
+
+RUN ./dist/video_agent/install_openh264.sh

--- a/docker/conference/docker-compose.yml
+++ b/docker/conference/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+
+  owt-server:
+    build:
+      context: ../
+      dockerfile: Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+    image: owt-server
+  owt-server-conference:
+    build:
+      context: .
+      dockerfile: Dockerfile-conference
+      args:
+        - http_proxy
+        - https_proxy
+    image: owt-server-conference
+    network_mode: host
+    ports:
+      - "3004:3004"
+    command: sh -c "service mongodb start && service rabbitmq-server start \
+                    && cd /owt-server/dist/bin && ./init-all.sh && ./start-all.sh && sleep infinity"
+    depends_on:
+      - owt-server


### PR DESCRIPTION
Adding Dockerfile and use docker compose to build owt-server in the docker container.  You can simply run docker-compose build to build the base image and docker-compose up to start the server with the conference sample, this helps resolve #16.