### PR TITLE
Fix build and pack issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In the root of the repository:
 1. Build native components: `scripts/build.js -t all --check`.
 2. Pack built components and js files: `scripts/pack.js -t all --install-module --sample-path ${webrtc-javascript-sdk-sample-conference-dist}`.
 
-The ${webrtc-javascript-sdk-sample-conference-dist} is built from owt-javascript-sdk, see https://github.com/open-webrtc-toolkit/owt-client-javascript for details.
+The ${webrtc-javascript-sdk-sample-conference-dist} is built from owt-javascript-sdk, e.g. `~/owt-client-javascript/dist/sample/conference`, see https://github.com/open-webrtc-toolkit/owt-client-javascript for details.
 
 If "--archive ${name}" option is appended to the pack command, a "Release-${name}.tgz" file will be generated in root folder. For other options, run the scripts with "--help" option.
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -5,6 +5,7 @@
 
 // building script
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { chdir, cwd } = process;
 const { execSync } = require('child_process');
@@ -95,10 +96,11 @@ function constructBuildEnv() {
 }
 
 // Common build commands
+var cpuCount = os.cpus().length;
 logLevel = options.verbose ? 'verbose' : 'error';
-rebuildArgs = ['node-gyp', 'rebuild', '-j 8', '--loglevel=' + logLevel];
+rebuildArgs = ['node-gyp', 'rebuild', `-j ${cpuCount}`, '--loglevel=' + logLevel];
 configureArgs = ['node-gyp', 'configure', '--loglevel=' + logLevel];
-buildArgs = ['node-gyp', 'build', '-j 8', '--loglevel=' + logLevel];
+buildArgs = ['node-gyp', 'build', `-j ${cpuCount}`, '--loglevel=' + logLevel];
 
 if (options.debug) {
   rebuildArgs.push('--debug');


### PR DESCRIPTION
1. In Ubuntu server with less than 8 cores, `-j 8` would hang the build process, using the number of cores could fix it;
2. Update scripts according to the new owt-client-javascript structure;