### PR TITLE
Enabling sending transport-cc feedback from MCU to publisher.

### DIFF
--- a/source/core/owt_base/VideoFrameConstructor.h
+++ b/source/core/owt_base/VideoFrameConstructor.h
@@ -19,7 +19,9 @@
 
 #include <JobTimer.h>
 #include <webrtc/modules/remote_bitrate_estimator/include/remote_bitrate_estimator.h>
+#include <webrtc/modules/remote_bitrate_estimator/remote_estimator_proxy.h>
 #include <webrtc/modules/rtp_rtcp/include/rtp_rtcp.h>
+#include <webrtc/modules/pacing/packet_router.h>
 #include <webrtc/modules/video_coding/include/video_codec_interface.h>
 #include <webrtc/modules/video_coding/include/video_coding.h>
 #include <webrtc/modules/video_coding/include/video_coding_defines.h>
@@ -117,6 +119,7 @@ private:
     boost::scoped_ptr<webrtc::RemoteBitrateEstimator> m_remoteBitrateEstimator;
     boost::scoped_ptr<webrtc::ViEReceiver> m_videoReceiver;
     boost::scoped_ptr<webrtc::RtpRtcp> m_rtpRtcp;
+    boost::scoped_ptr<webrtc::PacketRouter> m_packetRouter;
     boost::shared_mutex m_rtpRtcpMutex;
     boost::shared_ptr<WebRTCTransport<erizoExtra::VIDEO>> m_videoTransport;
 

--- a/source/core/rtc_adapter/VieReceiver.cc
+++ b/source/core/rtc_adapter/VieReceiver.cc
@@ -20,6 +20,7 @@
 #include "webrtc/modules/rtp_rtcp/include/rtp_payload_registry.h"
 #include "webrtc/modules/rtp_rtcp/include/rtp_receiver.h"
 #include "webrtc/modules/rtp_rtcp/include/rtp_rtcp.h"
+#include "webrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.h"
 #include "webrtc/modules/video_coding/include/video_coding.h"
 #include "webrtc/modules/video_coding/video_coding_impl.h"
 #include "webrtc/system_wrappers/include/metrics.h"
@@ -149,6 +150,16 @@ void ViEReceiver::RegisterSimulcastRtpRtcpModules(
     rtp_rtcp_simulcast_.insert(rtp_rtcp_simulcast_.begin(),
                                rtp_modules.begin(),
                                rtp_modules.end());
+  }
+}
+
+bool ViEReceiver::SetReceiveTransportSequenceNumberStatus(bool enable, int id) {
+  if (enable) {
+    return rtp_header_parser_->RegisterRtpHeaderExtension(
+        kRtpExtensionTransportSequenceNumber, id);
+  } else {
+    return rtp_header_parser_->DeregisterRtpHeaderExtension(
+        kRtpExtensionTransportSequenceNumber);
   }
 }
 

--- a/source/core/rtc_adapter/VieReceiver.h
+++ b/source/core/rtc_adapter/VieReceiver.h
@@ -71,6 +71,7 @@ class ViEReceiver : public RtpData {
 
   bool SetReceiveTimestampOffsetStatus(bool enable, int id);
   bool SetReceiveAbsoluteSendTimeStatus(bool enable, int id);
+  bool SetReceiveTransportSequenceNumberStatus(bool enable, int id);
 
   void StartReceive();
   void StopReceive();


### PR DESCRIPTION
With this we enable transport-cc feedback to publisher. We still don't handle transport-cc feedbacks from subscriber, as we're not adjusting bitrate on subscriber bandwidth change.