### PR TITLE
 Fix timestamps between contiguous mixed audio packets may vary

### DIFF
--- a/source/agent/audio/audioMixer/AcmEncoder.h
+++ b/source/agent/audio/audioMixer/AcmEncoder.h
@@ -57,6 +57,8 @@ private:
 
     uint32_t m_incomingFrameCount;
     boost::shared_ptr<AudioFrame> m_frame;
+
+    uint32_t m_lastTimestamp;
 };
 
 } /* namespace mcu */

--- a/source/agent/audio/audioMixer/AudioTime.cpp
+++ b/source/agent/audio/audioMixer/AudioTime.cpp
@@ -8,9 +8,9 @@
 
 namespace mcu {
 
-uint32_t AudioTime::sTimestampOffset = 0;
+uint64_t AudioTime::sTimestampOffset = 0;
 
-void AudioTime::setTimestampOffset(uint32_t offset)
+void AudioTime::setTimestampOffset(uint64_t offset)
 {
     sTimestampOffset = offset;
 }

--- a/source/agent/audio/audioMixer/AudioTime.h
+++ b/source/agent/audio/audioMixer/AudioTime.h
@@ -11,13 +11,12 @@
 namespace mcu {
 
 class AudioTime {
-
 public:
     static int64_t currentTime(void); //Millisecond
-    static void setTimestampOffset(uint32_t offset);
+    static void setTimestampOffset(uint64_t offset);
 
 private:
-    static uint32_t sTimestampOffset;
+    static uint64_t sTimestampOffset;
 
 };
 


### PR DESCRIPTION
We found timestamps between contiguous mixed audio packets may vary, which will mislead the client WebRTC neteq module make too much accelerations and expansions, and lead to the rhythm of music is very unstable, so I do this fix to make the timestamps between contiguous mixed audio packets stable as much as possible.

