### PR TITLE
Support config portal hostname and ip_address by env

### DIFF
--- a/source/portal/index.js
+++ b/source/portal/index.js
@@ -42,6 +42,16 @@ config.rabbit = config.rabbit || {};
 config.rabbit.host = config.rabbit.host || 'localhost';
 config.rabbit.port = config.rabbit.port || 5672;
 
+// Parse portal hostname and ip_address variables from ENV.
+if (config.portal.ip_address.indexOf('$') == 0) {
+    config.portal.ip_address = process.env[config.portal.ip_address.substr(1)];
+    log.info('ENV: config.portal.ip_address=' + config.portal.ip_address);
+}
+if (config.portal.hostname.indexOf('$') == 0) {
+    config.portal.hostname = process.env[config.portal.hostname.substr(1)];
+    log.info('ENV: config.portal.hostname=' + config.portal.hostname);
+}
+
 global.config = config;
 
 


### PR DESCRIPTION
For docker to pass variable by ENV:

```bash
[portal]
hostname = "$DOCKER_HOST" #default: ""
ip_address = "$DOCKER_IP" #default: ""
```

We can pass the host and ip to docker:

```
docker run -it -p 3004:3004 -p 3300:3300 -p 8080:8080 -p 60000-60050:60000-60050/udp \
    --env=DOCKER_HOST:owt-docker.me --env=DOCKER_IP:192.168.1.4 \
    registry.cn-hangzhou.aliyuncs.com/ossrs/owt:4.3 bash
```

Then, the portal config will be replaced as:

```bash
[portal]
hostname = "owt-docker.me" #default: ""
ip_address = "192.168.1.4" #default: ""
```

The logs:

```bash
starting portal, stdout -> /tmp/git/owt-docker/owt-server-4.3/dist/logs/portal.stdout
2020-03-03 05:01:41.861  - INFO: Main - ENV: config.portal.ip_address=192.168.1.4
2020-03-03 05:01:41.861  - INFO: Main - ENV: config.portal.hostname=owt-docker.me
```