### PR TITLE
Support config webrtc agent ip_address by env

### DIFF
--- a/source/agent/webrtc/configLoader.js
+++ b/source/agent/webrtc/configLoader.js
@@ -66,6 +66,12 @@ module.exports.load = () => {
         process.exit(1);
       }
       item.ip_address = addr.ip;
+
+      // Parse webrtc ip_address variables from ENV.
+      if (item.replaced_ip_address && item.replaced_ip_address.indexOf('$') == 0) {
+        item.replaced_ip_address = process.env[item.replaced_ip_address.substr(1)];
+        console.log('ENV: config.webrtc.network_interfaces[' + item.name + '].replaced_ip_address=' + item.replaced_ip_address);
+      }
     });
 
     return config;


### PR DESCRIPTION
For docker to pass variable by ENV:

```bash
[webrtc]
network_interfaces = [{name="eth0",replaced_ip_address="$DOCKER_HOST"}]  # default: []
```

We can pass the host and ip to docker:

```
docker run -it -p 3004:3004 -p 3300:3300 -p 8080:8080 -p 60000-60050:60000-60050/udp \
    --env=DOCKER_IP:192.168.1.4 \
    registry.cn-hangzhou.aliyuncs.com/ossrs/owt:4.3 bash
```

Then, the portal config will be replaced as:

```bash
[webrtc]
network_interfaces = [{name="eth0",replaced_ip_address="192.168.1.4"}]  # default: []
```

The logs:

```bash
starting webrtc-agent, stdout -> /tmp/git/owt-docker/owt-server-4.3/dist/logs/webrtc-agent.stdout
ENV: config.webrtc.network_interfaces[eth0].replaced_ip_address=192.168.1.4
```