### PR TITLE
Make installing an app into the owt-server Docker image much easier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The media server can be built on following platforms:
 ### Instructions
 In the root of the repository:
 1. Build native components: `scripts/build.js -t all --check`.
-2. Pack built components and js files: `scripts/pack.js -t all --install-module --sample-path ${webrtc-javascript-sdk-sample-conference-dist}`.
+2. Pack built components and js files: `scripts/pack.js -t all --install-module --app-path ${webrtc-javascript-sdk-sample-conference-dist}`.
 
 The ${webrtc-javascript-sdk-sample-conference-dist} is built from owt-javascript-sdk, e.g. `~/owt-client-javascript/dist/sample/conference`, see https://github.com/open-webrtc-toolkit/owt-client-javascript for details.
 
@@ -41,6 +41,13 @@ In the repository root, run following commands to start media server on single m
 
 ## Where to find API documents
 See "doc/servermd/Server.md" and "doc/servermd/RESTAPI.md".
+
+## Build a Docker image with your app
+Run the build_server.sh script located in docker/conference. It has one required flag, -p, which should contain the filepath of your app. Optional flags are -i for the final Docker image name, and -n
+which will make the Docker build run with --no-cache. An example usecase..
+```
+./docker/conference/build_server.sh -p ~/my_app -i myapp_img
+```
 
 ## How to contribute
 We warmly welcome community contributions to Open WebRTC Toolkit Media Server repository. If you are willing to contribute your features and ideas to OWT, follow the process below:

--- a/doc/servermd/Server.md
+++ b/doc/servermd/Server.md
@@ -180,7 +180,7 @@ After editing the configuration file, you should run `./initcert.js` inside each
 | DTLS-SRTP | webrtc_agent/agent.toml |
 | management-console HTTPS | management_console/management_console.toml |
 
-For OWT sample application's certificate configuration, please follow the instruction file 'README.md' located at Release-<Version>/extras/basic_example/.
+For OWT sample application's certificate configuration, please follow the instruction file 'README.md' located at Release-<Version>/apps/current_app/.
 
 ### 2.3.8 Launch the OWT server as single node {#Conferencesection2_3_8}
 To launch the OWT server on one machine, follow steps below:
@@ -277,7 +277,7 @@ Follow the steps below to set up a OWT server cluster:
 
         cd Release-<Version>/
         bin/daemon.sh start app
-   > **Note**: You can also deploy the sample application server on separated machine, follow instructions at Release-<Version>/extras/basic_example/README.md
+   > **Note**: You can also deploy the sample application server on separated machine, follow instructions at Release-<Version>/apps/current_app/README.md
 
 7. Choose machines to run cluster-managers. These machines do not need to be visible to clients, but should be visible to management-api and all workers.
 8. Edit the configurations of cluster-manager in Release-<Version>/cluster_manager/cluster_manager.toml.
@@ -738,7 +738,7 @@ Only super service user can access runtime configuration. Current management con
 ## 4.1 Introduction {#Conferencesection4_1}
 The OWT sample application server is a Web application demo that shows how to host audio/video conference services powered by the Open WebRTC Toolkit. The sample application server is based on OWT runtime components. Refer to [Section 2](#Conferencesection2) of this guide, for system requirements and launch/stop instructions.
 
-The source code of the sample application is in Release-<Version>/extras/basic_example/.
+The source code of the sample application is in Release-<Version>/apps/current_app/.
 
 This section explains how to start a conference and then connect to a conference using different qualifiers, such as a specific video resolution.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,8 @@ FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MEDIA_SDK_VER=18.4.0
+ARG IMG_APP_PATH=/app_data/
+ENV APP_PATH=${IMG_APP_PATH}
 
 # Update the system
 RUN apt-get update
@@ -18,17 +20,14 @@ RUN npm install -g grunt-cli node-gyp
 
 # Keep proxy environment for sudo
 RUN bash -c "echo \"Defaults env_keep = \\\"http_proxy https_proxy no_proxy \\\"\" >> /etc/sudoers"
-
-# Install owt-client
-RUN git clone https://github.com/open-webrtc-toolkit/owt-client-javascript.git
-RUN cd owt-client-javascript/scripts && npm install && grunt
-
 RUN wget https://github.com/Intel-Media-SDK/MediaSDK/releases/download/intel-mediasdk-$MEDIA_SDK_VER/MediaStack.tar.gz -P /tmp
 RUN cd /tmp && tar -zxf MediaStack.tar.gz && cd MediaStack && ./install_media.sh
 RUN rm /tmp/MediaStack.tar.gz && rm -rf /tmp/MediaStack
 ENV MFX_HOME=/opt/intel/mediasdk
 
 RUN git clone https://github.com/open-webrtc-toolkit/owt-server.git
+RUN mkdir -p ${APP_PATH}
+
 WORKDIR /owt-server
 
 # This is needed to patch licode
@@ -36,3 +35,6 @@ RUN  git config --global user.email "you@example.com" && \
   git config --global user.name "Your Name"
 
 RUN ./scripts/installDepsUnattended.sh
+
+# Set workpath to where the app should be installed for the next step of the multibuild
+WORKDIR ${APP_PATH}

--- a/docker/conference/Dockerfile-conference
+++ b/docker/conference/Dockerfile-conference
@@ -1,13 +1,9 @@
 ################################
 # OWT WebRTC Conference Sample
 
-FROM owt-server:latest
-
-ENV CLIENT_SAMPLE_PATH=/owt-client-javascript/dist/samples/conference
+FROM owt-server-conference-install:latest
 
 WORKDIR /owt-server
-
 RUN ./scripts/build.js -t all --check
-RUN ./scripts/pack.js -t all --install-module --sample-path $CLIENT_SAMPLE_PATH .
-
+RUN ./scripts/pack.js -t all --install-module --app-path ${APP_PATH} .
 RUN ./dist/video_agent/install_openh264.sh

--- a/docker/conference/build_server.sh
+++ b/docker/conference/build_server.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+options() {
+	echo "Usage: $0 [ -p FILEPATH ] [ -i IMAGE_NAME ]" >&2
+	echo " -p App directory" >&2
+	echo " -i Docker image name" >&2
+	echo " -n Request docker use --no-cache" >&2
+}
+echo "Number of args $# $*"
+if [[ $* != *-p* ]]; then
+	echo "-p is required"
+	exit 1
+fi
+
+DIRNAME=$(dirname "$0")
+REALPATH=$(realpath "$DIRNAME")
+IMG="owt-server-conference"
+NO_CACHE="";
+
+while getopts p:i:n flag; do
+	case "${flag}" in
+	p)
+		echo "using flag: -$flag"
+		if [[ ${OPTARG} == "." ]]; then
+			LOCAL_APP_PATH=$PWD
+		else
+			LOCAL_APP_PATH=$(realpath "${OPTARG}")
+		fi
+		LOCAL_APP_FOLDER=$(basename "$LOCAL_APP_PATH")
+		LOCAL_APP_PATH=$(dirname "$LOCAL_APP_PATH")
+		;;
+	i)
+		echo "using flag: -$flag"
+		IMG=${OPTARG}
+		;;
+	n)
+		NO_CACHE="--no-cache"
+		;;
+	\?)
+		echo "Invalid option: -$flag ${OPTARG}"
+		options
+		exit 1
+		;;
+	:)
+		echo "option -$flag requires an argument."
+		exit 1
+		;;
+	esac
+done
+
+export DOCKER_IMG_NAME=$IMG
+export DOCKERFILE_PATH=$REALPATH
+export LOCAL_APP_PATH=$LOCAL_APP_PATH
+export LOCAL_APP_FOLDER=$LOCAL_APP_FOLDER
+
+echo Adding app in folder ${LOCAL_APP_PATH}/${LOCAL_APP_FOLDER} to Docker image ${DOCKER_IMG_NAME} ${NO_CACHE}
+
+docker-compose -f "${DOCKERFILE_PATH}/docker-compose.yml" build ${NO_CACHE}

--- a/docker/conference/docker-compose.yml
+++ b/docker/conference/docker-compose.yml
@@ -9,18 +9,32 @@ services:
         - http_proxy
         - https_proxy
     image: owt-server
-  owt-server-conference:
+
+  # Copy the requested app to the owt-server image
+  owt-server-conference-install:
     build:
-      context: .
-      dockerfile: Dockerfile-conference
+      context: ${LOCAL_APP_PATH}
+      dockerfile: "${LOCAL_APP_PATH}/${LOCAL_APP_FOLDER}/Dockerfile"
       args:
         - http_proxy
         - https_proxy
-    image: owt-server-conference
+    image: owt-server-conference-install
+    depends_on:
+      - owt-server
+
+  # Build the server image and install the app
+  owt-server-conference-build:
+    build:
+      context: ${LOCAL_APP_PATH}
+      dockerfile: "${DOCKERFILE_PATH}/Dockerfile-conference"
+      args:
+        - http_proxy
+        - https_proxy
+    image: "${DOCKER_IMG_NAME}"
     network_mode: host
     ports:
       - "3004:3004"
     command: sh -c "service mongodb start && service rabbitmq-server start \
                     && cd /owt-server/dist/bin && ./init-all.sh && ./start-all.sh && sleep infinity"
     depends_on:
-      - owt-server
+      -  owt-server-conference-install

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -618,7 +618,8 @@ function packApps() {
     return;
   } else {
     // Make a soft link to the main JS file node.js should call
-    execSync(`ln -sf ${distDir}/apps/current_app/${appJSON} ${distDir}/apps/current_app/main.js`);
+    if (appJSON !== 'main.js')
+      execSync(`ln -sf ${distDir}/apps/current_app/${appJSON} ${distDir}/apps/current_app/main.js`);
   }
   const certScript = `${distDir}/apps/current_app/initcert.js`;
   if (fs.existsSync(certScript))

--- a/scripts/release/daemon-bin.sh
+++ b/scripts/release/daemon-bin.sh
@@ -176,8 +176,8 @@ case $startStop in
         echo $! > ${pid}
         ;;
       app )
-        cd ${OWT_HOME}/extras/basic_example/
-        nohup nice -n ${OWT_NICENESS} node samplertcservice.js \
+        cd ${OWT_HOME}/apps/current_app/
+        nohup nice -n ${OWT_NICENESS} node main.js \
           > "${stdout}" 2>&1 </dev/null &
         echo $! > ${pid}
         ;;

--- a/scripts/release/daemon-mcu.sh
+++ b/scripts/release/daemon-mcu.sh
@@ -184,8 +184,8 @@ case $startStop in
         echo $! > ${pid}
         ;;
       app )
-        cd ${OWT_HOME}/extras/basic_example/
-        nohup nice -n ${OWT_NICENESS} node samplertcservice.js \
+        cd ${OWT_HOME}/apps/current_app/
+        nohup nice -n ${OWT_NICENESS} node main.js \
           > "${stdout}" 2>&1 </dev/null &
         echo $! > ${pid}
         ;;

--- a/source/management_api/initdb.js
+++ b/source/management_api/initdb.js
@@ -20,7 +20,7 @@ var cipher = require('./cipher');
 
 var dirName = !process.pkg ? __dirname : path.dirname(process.execPath);
 var configFile = path.join(dirName, 'management_api.toml');
-var sampleServiceFile = path.resolve(dirName, '../extras/basic_example/samplertcservice.js');
+var sampleServiceFile = path.resolve(dirName, '../apps/current_app/samplertcservice.js');
 
 function prepareDB(next) {
   if (fs.existsSync(cipher.astore)) {

--- a/source/management_api/initdb.js
+++ b/source/management_api/initdb.js
@@ -20,7 +20,7 @@ var cipher = require('./cipher');
 
 var dirName = !process.pkg ? __dirname : path.dirname(process.execPath);
 var configFile = path.join(dirName, 'management_api.toml');
-var sampleServiceFile = path.resolve(dirName, '../apps/current_app/samplertcservice.js');
+var sampleServiceFile = path.resolve(dirName, '../apps/current_app/main.js');
 
 function prepareDB(next) {
   if (fs.existsSync(cipher.astore)) {

--- a/test/restTestCasesKarma/karma.conf.js
+++ b/test/restTestCasesKarma/karma.conf.js
@@ -6,7 +6,7 @@ module.exports = function (config) {
       'dependencies/adapter-7.0.0.js',
       'dependencies/jquery-3.2.1.min.js',
       'dependencies/socket.io.js',
-      '../dist/extras/basic_example/public/scripts/owt.js',
+      '../dist/apps/current_app/public/scripts/owt.js',
       'test/restJsCase.js',
     ],
     protocol: 'http:',


### PR DESCRIPTION
Now the app maker doesn't need to have a deep
understanding of the owt-server file system. They can simply run
build_server.sh and it will take care of the rest. Also, now apps
can use whatever name they want for the main JS file, rather than
the hard coded samplertcservice.js. It also allows the app maker
to name the final Docker image what they.