### PR TITLE
Need to use a newer version of NPM

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,9 @@ ENV APP_PATH=${IMG_APP_PATH}
 RUN apt-get update
 
 # Install utils
-RUN apt-get install -y ca-certificates git lsb-release mongodb nodejs npm sudo wget
+RUN apt-get install -y ca-certificates git lsb-release mongodb nodejs curl sudo wget
+# Get latest NPM
+RUN curl -L https://www.npmjs.com/install.sh | sh
 
 RUN npm install -g grunt-cli node-gyp
 


### PR DESCRIPTION
Building the Docker image will fail in pack.js
due to NPM being too old (3.5.2) in Ubuntu 18.04.
Changing the Dockerfile to use the latest.