### PR TITLE
Don't use sudo in dependencies scripts if already root

### DIFF
--- a/scripts/installCentOSDeps.sh
+++ b/scripts/installCentOSDeps.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+SUDO=""
+if [[ $EUID -ne 0 ]]; then
+   SUDO="sudo -E"
+fi
+
 install_glib2(){
   if [ -d $LIB_DIR ]; then
     # libffi
@@ -47,17 +52,17 @@ install_boost(){
 }
 
 installYumDeps(){
-  sudo -E yum groupinstall " Development Tools" "Development Libraries " -y
-  sudo -E yum install zlib-devel pkgconfig git libcurl-devel.x86_64 curl log4cxx-devel gcc gcc-c++ bzip2 bzip2-devel bzip2-libs python-devel nasm libXext-devel libXfixes-devel libpciaccess-devel libX11-devel yasm cmake -y
-  sudo -E yum install rabbitmq-server mongodb mongodb-server java-1.7.0-openjdk gyp intel-gpu-tools which libtool freetype-devel -y
-  sudo -E yum install glib2-devel boost-devel -y
+  ${SUDO} yum groupinstall " Development Tools" "Development Libraries " -y
+  ${SUDO} yum install zlib-devel pkgconfig git libcurl-devel.x86_64 curl log4cxx-devel gcc gcc-c++ bzip2 bzip2-devel bzip2-libs python-devel nasm libXext-devel libXfixes-devel libpciaccess-devel libX11-devel yasm cmake -y
+  ${SUDO} yum install rabbitmq-server mongodb mongodb-server java-1.7.0-openjdk gyp intel-gpu-tools which libtool freetype-devel -y
+  ${SUDO} yum install glib2-devel boost-devel -y
 }
 
 installRepo(){
   wget -c http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   wget -c http://rpms.famillecollet.com/enterprise/remi-release-7.rpm
-  sudo rpm -Uvh remi-release-7*.rpm epel-release-latest-7*.rpm
-  sudo sed -i 's/https/http/g' /etc/yum.repos.d/epel.repo
+  ${SUDO} rpm -Uvh remi-release-7*.rpm epel-release-latest-7*.rpm
+  ${SUDO} sed -i 's/https/http/g' /etc/yum.repos.d/epel.repo
   rm *.rpm
 }
 

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+SUDO=""
+if [[ $EUID -ne 0 ]]; then
+   SUDO="sudo -E"
+fi
+
 install_apt_deps(){
-  sudo -E apt-get update -y
-  sudo -E apt-get install git make gcc g++ libglib2.0-dev pkg-config libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx-dev rabbitmq-server mongodb openjdk-8-jre curl libboost-test-dev nasm yasm gyp libx11-dev libkrb5-dev intel-gpu-tools m4 autoconf libtool automake cmake libfreetype6-dev -y
+  ${SUDO} apt-get update -y
+  ${SUDO} apt-get install git make gcc g++ libglib2.0-dev pkg-config libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx-dev rabbitmq-server mongodb openjdk-8-jre curl libboost-test-dev nasm yasm gyp libx11-dev libkrb5-dev intel-gpu-tools m4 autoconf libtool automake cmake libfreetype6-dev -y
 }
 
 install_mediadeps_nonfree(){


### PR DESCRIPTION
Other scripts were already doing this; this allows the scripts
to be run in Docker without needlessly installing sudo.