### PR TITLE
Opt for cluster deployment

### DIFF
--- a/source/agent/analytics/agent.toml
+++ b/source/agent/analytics/agent.toml
@@ -15,6 +15,8 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
+#The load type, e.g. cpu, disk, network
+load_type = "cpu"
 #The max load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
 

--- a/source/agent/analytics/configLoader.js
+++ b/source/agent/analytics/configLoader.js
@@ -24,9 +24,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'cpu'
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'cpu';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.internal.ip_address = config.internal.ip_address || '';
     config.internal.network_interface = config.internal.network_interface || undefined;

--- a/source/agent/audio/agent.toml
+++ b/source/agent/audio/agent.toml
@@ -15,6 +15,8 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
+#The load type, e.g. cpu, disk, network
+load_type = "cpu"
 #The max CPU load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
 

--- a/source/agent/audio/configLoader.js
+++ b/source/agent/audio/configLoader.js
@@ -23,9 +23,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'cpu'
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'cpu';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.capacity = config.capacity || {};
 

--- a/source/agent/conference/agent.toml
+++ b/source/agent/conference/agent.toml
@@ -16,6 +16,8 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
+#The load type, e.g. cpu, disk, network
+load_type = "cpu"
 #The max CPU load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
 

--- a/source/agent/conference/configLoader.js
+++ b/source/agent/conference/configLoader.js
@@ -23,9 +23,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'cpu'
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'cpu';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.capacity = config.capacity || {};
 

--- a/source/agent/index.js
+++ b/source/agent/index.js
@@ -108,6 +108,7 @@ var joinCluster = function (on_ok) {
     });
 };
 
+var rabbit_config_copy = Object.assign({}, config.rabbit);
 var init_manager = () => {
   var reuseNode = !(myPurpose === 'audio'
     || myPurpose === 'video'
@@ -122,6 +123,7 @@ var init_manager = () => {
   };
 
   spawnOptions.config.purpose = myPurpose;
+  spawnOptions.config.rabbit = rabbit_config_copy;
 
   manager = nodeManager(
     {

--- a/source/agent/recording/agent.toml
+++ b/source/agent/recording/agent.toml
@@ -15,6 +15,8 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
+#The load type, e.g. cpu, disk, network
+load_type = "disk"
 #The max disk load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
 

--- a/source/agent/recording/configLoader.js
+++ b/source/agent/recording/configLoader.js
@@ -23,9 +23,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'disk'
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'disk';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.capacity = config.capacity || {};
 

--- a/source/agent/sip/agent.toml
+++ b/source/agent/sip/agent.toml
@@ -15,6 +15,8 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
+#The load type, e.g. cpu, disk, network
+load_type = "cpu"
 #The max CPU load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
 

--- a/source/agent/sip/configLoader.js
+++ b/source/agent/sip/configLoader.js
@@ -23,9 +23,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'cpu'
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'cpu';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.capacity = config.capacity || {};
 

--- a/source/agent/streaming/agent.toml
+++ b/source/agent/streaming/agent.toml
@@ -15,6 +15,8 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
+#The load type, e.g. cpu, disk, network
+load_type = "network"
 #The max network load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
 

--- a/source/agent/streaming/configLoader.js
+++ b/source/agent/streaming/configLoader.js
@@ -23,11 +23,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'network',
-      interf: 'lo',
-      max_scale: config.cluster.network_max_scale || 1000
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'network';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.capacity = config.capacity || {};
 

--- a/source/agent/video/agent.toml
+++ b/source/agent/video/agent.toml
@@ -15,6 +15,8 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
+#The load type, e.g. cpu, disk, network
+load_type = "cpu"
 #The max CPU/GPU load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
 

--- a/source/agent/video/configLoader.js
+++ b/source/agent/video/configLoader.js
@@ -23,9 +23,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'cpu'
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'cpu';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.internal.ip_address = config.internal.ip_address || '';
     config.internal.network_interface = config.internal.network_interface || undefined;

--- a/source/agent/webrtc/agent.toml
+++ b/source/agent/webrtc/agent.toml
@@ -15,11 +15,10 @@ join_retry = 60 #default: 60
 #The interval of reporting the work load
 report_load_interval = 1000 #default: 1000, unit: millisecond
 
-#The max network load under which this worker can take new tasks.
+#The load type, e.g. cpu, disk, network
+load_type = "cpu"
+#The max load under which this worker can take new tasks.
 max_load = 0.85 #default: 0.85
-
-#The bandwidth of network-interface used for WebRTC peerconnections. 
-network_max_scale = 1000 #unit: Mbps
 
 
 [capacity]

--- a/source/agent/webrtc/configLoader.js
+++ b/source/agent/webrtc/configLoader.js
@@ -23,11 +23,12 @@ module.exports.load = () => {
     config.cluster.worker.load = config.cluster.worker.load || {};
     config.cluster.worker.load.max = config.cluster.max_load || 0.85;
     config.cluster.worker.load.period = config.cluster.report_load_interval || 1000;
-    config.cluster.worker.load.item = {
-      name: 'network',
-      interf: 'lo',
-      max_scale: config.cluster.network_max_scale || 1000
-    };
+    config.cluster.worker.load.item = {};
+    config.cluster.worker.load.item.name = config.cluster.load_type || 'cpu';
+    if (config.cluster.worker.load.item.name === 'network') {
+      config.cluster.worker.load.interf = 'lo';
+      config.cluster.worker.load.max_scale = config.cluster.network_max_scale || 1000;
+    }
 
     config.capacity = config.capacity || {};
     config.capacity.isps = config.capacity.isps || [];


### PR DESCRIPTION
1. fix none-default rabbitmq user connect issue;
2. make load type configurable, and change default load type of webrtc agent to CPU, usually CPU is the bottleneck when deployed on machine charged by traffic, rather then bandwidth;