### PR TITLE
Fix broken download of openssl-1.0.2t.tar.gz

### DIFF
--- a/scripts/installCommonDeps.sh
+++ b/scripts/installCommonDeps.sh
@@ -149,12 +149,13 @@ install_openssl(){
   $INCR_INSTALL && [[ ! -z $LIST_LIBS ]] && echo "openssl already installed." && return 0
 
   if [ -d $LIB_DIR ]; then
+    local SSL_BASE_VERSION="1.0.2"
     local SSL_VERSION="1.0.2t"
     cd $LIB_DIR
     rm -f ./build/lib/libssl.*
     rm -f ./build/lib/libcrypto.*
     rm -rf openssl-1*
-    wget -c http://www.openssl.org/source/openssl-${SSL_VERSION}.tar.gz
+    wget -c http://www.openssl.org/source/old/${SSL_BASE_VERSION}/openssl-${SSL_VERSION}.tar.gz
     tar xf openssl-${SSL_VERSION}.tar.gz
     cd openssl-${SSL_VERSION}
     ./config no-ssl3 --prefix=$PREFIX_DIR -fPIC


### PR DESCRIPTION
I'm not sure how we manage these release branches, but it looks like maybe 4.3.x is a place to patch fixes? This version of openssl has moved to a new location in an old/ subdirectory.

Do we ever advance the v4.3 tag? Should we advise people to build from 4.3.x if they want to use 4.3?
