### PR TITLE
Give helpful warning when ldd doesn't find a dependency

### DIFF
--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -393,6 +393,17 @@ function getAddonLibs(addonPath) {
                   return line;
                 }).catch((e) => line);
             }
+          })
+          .catch((e) => {
+            // give more detail when ldd returns somelib.so => not found
+            if (!line.startsWith('/')) {
+              return exec(`ldd ${addonPath} | grep '=>' | grep -v '=> /'`).then(stdout => {
+                e.message = `library dependency not found for\n  ${addonPath}:\n${stdout}` +
+                  'Something failed to build. Try nvm use v8.15.0 and rerun build.js.';
+                throw e;
+              });
+            }
+            throw e;
           });
         checks.push(checkPros[line]);
       }


### PR DESCRIPTION
When the ldd command here returned something like:
	sipLib.so => not found
the previous code would report a cryptic error:
Error: Command failed: [ -s not ]