### PR TITLE
fix: cluster_manager stop working if !!Double master!! status occur

### DIFF
--- a/source/common/amqp_client.js
+++ b/source/common/amqp_client.js
@@ -155,7 +155,7 @@ var rpcServer = function(bus, conn, id, methods, on_ready, on_failure) {
     }, on_failure);
 
     handler.close = function() {
-        request_q && request_q.destroy();
+        request_q && request_q.destroy({ifUnused : true});
         request_q = undefined;
         exc && exc.destroy(true);
         exc = undefined;


### PR DESCRIPTION
### summary
1. 2 cluster_manager, one for master, another for slave.
2. cluster_manager stop working and whole cluster stopped service.

### refer: https://github.com/open-webrtc-toolkit/owt-server/issues/530