### PR TITLE
update 4 years old nvm and fix openssl lib64 issue in centos 7

### DIFF
--- a/scripts/installCommonDeps.sh
+++ b/scripts/installCommonDeps.sh
@@ -160,7 +160,7 @@ install_openssl(){
     wget -c https://www.openssl.org/source/openssl-${SSL_VERSION}.tar.gz
     tar xf openssl-${SSL_VERSION}.tar.gz
     cd openssl-${SSL_VERSION}
-    ./config no-ssl3 --prefix=$PREFIX_DIR -fPIC
+    ./config no-ssl3 --prefix=$PREFIX_DIR -fPIC --libdir=lib
     make depend
     make -s V=0
     make install

--- a/scripts/install_nvm.sh
+++ b/scripts/install_nvm.sh
@@ -13,7 +13,7 @@ if [ -z "$NVM_DIR" ]; then
 fi
 
 nvm_latest_version() {
-  echo "v0.27.1"
+  echo "v0.37.2"
 }
 
 #


### PR DESCRIPTION
0.27.1 is 4 years old