### PR TITLE
Implement close for QUIC stream.

### DIFF
--- a/source/agent/addons/quic/QuicTransportStream.cc
+++ b/source/agent/addons/quic/QuicTransportStream.cc
@@ -101,6 +101,12 @@ NAN_METHOD(QuicTransportStream::write)
     info.GetReturnValue().Set(Nan::New(static_cast<int>(written)));
 }
 
+NAN_METHOD(QuicTransportStream::close)
+{
+    QuicTransportStream* obj = Nan::ObjectWrap::Unwrap<QuicTransportStream>(info.Holder());
+    obj->m_stream->Close();
+}
+
 NAN_METHOD(QuicTransportStream::addDestination)
 {
     QuicTransportStream* obj = Nan::ObjectWrap::Unwrap<QuicTransportStream>(info.Holder());

--- a/source/agent/addons/quic/QuicTransportStream.h
+++ b/source/agent/addons/quic/QuicTransportStream.h
@@ -32,6 +32,7 @@ public:
     static NAN_MODULE_INIT(init);
     static NAN_METHOD(newInstance);
     static NAN_METHOD(write);
+    static NAN_METHOD(close);
     static NAN_METHOD(addDestination);
     static NAN_METHOD(removeDestination);
     static NAUV_WORK_CB(onContentSessionId);

--- a/source/agent/quic/webtransport/quicTransportStreamPipeline.js
+++ b/source/agent/quic/webtransport/quicTransportStreamPipeline.js
@@ -51,7 +51,6 @@ module.exports = class QuicTransportStreamPipeline {
     };
 
     this.close = function(){
-      return;
       this._quicStream.close();
     }
   }


### PR DESCRIPTION
This change also closes unauthenticated connections in expected time and avoid duplicated signaling streams.