### PR TITLE
Fix for wrong MongDB URL

### DIFF
--- a/source/management_api/initdb.js
+++ b/source/management_api/initdb.js
@@ -41,9 +41,9 @@ function prepareDB(next) {
     cipher.unlock(cipher.k, cipher.astore, function cb (err, authConfig) {
       if (!err) {
         if (authConfig.mongo && !dbURL.includes('@')) {
-          dbURL = authConfig.mongo.username
+          dbURL = "mongodb://" + authConfig.mongo.username
             + ':' + authConfig.mongo.password
-            + '@' + dbURL;
+            + '@' + dbURL.replace("mongodb://", "");
         }
       } else {
         console.error('Failed to get mongodb auth:', err);


### PR DESCRIPTION
Because of wrong URL concatenation the MongoDB URL is wrong and initdb.js script fails on execution. 