### PR TITLE
Don't require os and runtime info.

### DIFF
--- a/doc/Client-Portal Protocol.md
+++ b/doc/Client-Portal Protocol.md
@@ -99,6 +99,7 @@ This a format for client reconnects.
 
 **RequestData**: The LoginInfo object with following definition:
 
+```
   object(LoginInfo)::
     {
      token: string(Base64EncodedToken),
@@ -115,14 +116,6 @@ This a format for client reconnects.
        sdk: {
          type: string(SDKName),
          version: string(SDKVersion)
-        },
-       runtime: {
-         name: string(RuntimeName),
-         version: string(RuntimeVersion)
-        },
-       os: {
-         name: string(OSName),
-         version: string(OSVersion)
         }
       }
 
@@ -130,8 +123,11 @@ This a format for client reconnects.
       {
        keepTime: number(Seconds)/*-1: Use server side configured 'reconnection_timeout' value; Others: specified keepTime in seconds*/
       }
+```
+
 **ResponseData**: The LoginResult object with following definition if **ResponseStatus** is "ok":
 
+```
     object(LoginResult)::
       {
        id: string(ParticipantId),
@@ -311,6 +307,8 @@ This a format for client reconnects.
          notAfter: number(ValidTimeEnd),
          signature: string(Signature)
         }
+```
+
 ### 3.3.2 Participant Leaves a Room
 **RequestName**: “logout”<br>
 

--- a/source/portal/socketIOServer.js
+++ b/source/portal/socketIOServer.js
@@ -48,7 +48,7 @@ var Connection = function(spec, socket, reconnectionKey, portal, dock) {
   };
 
   const validateUserAgent = function(ua){
-    if(!ua||!ua.sdk||!ua.sdk.version||!ua.sdk.type||!ua.runtime||!ua.runtime.version||!ua.runtime.name||!ua.os||!ua.os.version||!ua.os.name){
+    if(!ua||!ua.sdk||!ua.sdk.version||!ua.sdk.type) {
       return Promise.reject('User agent info is incorrect');
     }
     return Promise.resolve(ua.sdk.type === 'Objective-C' || ua.sdk.type === 'C++' || ua.sdk.type === 'Android' || ua.sdk.type == 'JavaScript')


### PR DESCRIPTION
Requires as less info as possible.

In P2P mode, instead of using browser version to determine whether a
feature is supported by remote side or not, we use capability map to
indicate whether a feature is supported.