### PR TITLE
Resolve pooling issues in nodeManager

### DIFF
--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -240,6 +240,7 @@ module.exports = function (spec, spawnOptions, onNodeAbnormallyQuit, onTaskAdded
       if (idle_nodes.length < 1) {
         log.error('getNode error:', 'No available node');
         reject('No available node');
+        return;
       }
   
       let node_id = idle_nodes.shift();

--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -155,7 +155,7 @@ module.exports = function (spec, spawnOptions, onNodeAbnormallyQuit, onTaskAdded
   var fillNodes = function() {
       var runningNodes = nodes.length + idle_nodes.length;
       var spaceInIdle = spec.prerunNodeNum - idle_nodes.length;
-      var nodesToStart = spec.maxNodeNum < 0 ? spaceInIdle : min(spaceInIdle, spec.maxNodeNum - runningNodes);
+      var nodesToStart = spec.maxNodeNum < 0 ? spaceInIdle : Math.min(spaceInIdle, spec.maxNodeNum - runningNodes);
 
       for (var i = 0; i < nodesToStart; i++) {
           launchNode();

--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -153,7 +153,11 @@ module.exports = function (spec, spawnOptions, onNodeAbnormallyQuit, onTaskAdded
   };
   
   var fillNodes = function() {
-      for (var i = idle_nodes.length; i < spec.prerunNodeNum; i++) {
+      var runningNodes = nodes.length + idle_nodes.length;
+      var spaceInIdle = spec.prerunNodeNum - idle_nodes.length;
+      var nodesToStart = spec.maxNodeNum < 0 ? spaceInIdle : min(spaceInIdle, spec.maxNodeNum - runningNodes);
+
+      for (var i = 0; i < nodesToStart; i++) {
           launchNode();
       }
   };


### PR DESCRIPTION
* **Prevent that undefined ends up in the nodes array**
In the case where there was no available node after the rejection of the promise, the value `undefined` was pushed into the `nodes` array. This has caused the node array to have values that shouldn't be there. This was one of the reasons that fillNodes wasn't called anymore even when the idle_nodes was empty and the number of running nodes had not reached the limit.
![image](https://user-images.githubusercontent.com/5446019/117819879-4511bd00-b26a-11eb-89f9-d563b7d8b984.png)

* **Do not start more nodes than maxNodeNum**
After a node has been closed, the fillNodes function was called without any checks. Because of this, it did always fill up the array to `spec.prerunNodeNum` nodes. This caused that it was possible to have 10 nodes running while the limit was configured to 5.