### PR TITLE
Correctly recover the nodeManager after agent recovery

### DIFF
--- a/source/agent/index.js
+++ b/source/agent/index.js
@@ -79,6 +79,7 @@ var joinCluster = function (on_ok) {
 
     var recovery = function () {
         log.info(myPurpose, 'agent recovered.');
+        manager && manager.recover();
     };
 
     var overload = function () {

--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -240,6 +240,7 @@ module.exports = function (spec, spawnOptions, onNodeAbnormallyQuit, onTaskAdded
       if (idle_nodes.length < 1) {
         log.error('getNode error:', 'No available node');
         reject('No available node');
+        return;
       }
   
       let node_id = idle_nodes.shift();

--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -155,7 +155,7 @@ module.exports = function (spec, spawnOptions, onNodeAbnormallyQuit, onTaskAdded
   var fillNodes = function() {
       var runningNodes = nodes.length + idle_nodes.length;
       var spaceInIdle = spec.prerunNodeNum - idle_nodes.length;
-      var nodesToStart = spec.maxNodeNum < 0 ? spaceInIdle : min(spaceInIdle, spec.maxNodeNum - runningNodes);
+      var nodesToStart = spec.maxNodeNum < 0 ? spaceInIdle : Math.min(spaceInIdle, spec.maxNodeNum - runningNodes);
 
       for (var i = 0; i < nodesToStart; i++) {
           launchNode();

--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -153,7 +153,11 @@ module.exports = function (spec, spawnOptions, onNodeAbnormallyQuit, onTaskAdded
   };
   
   var fillNodes = function() {
-      for (var i = idle_nodes.length; i < spec.prerunNodeNum; i++) {
+      var runningNodes = nodes.length + idle_nodes.length;
+      var spaceInIdle = spec.prerunNodeNum - idle_nodes.length;
+      var nodesToStart = spec.maxNodeNum < 0 ? spaceInIdle : min(spaceInIdle, spec.maxNodeNum - runningNodes);
+
+      for (var i = 0; i < nodesToStart; i++) {
           launchNode();
       }
   };

--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -316,6 +316,11 @@ module.exports = function (spec, spawnOptions, onNodeAbnormallyQuit, onTaskAdded
       reject('No such a task');
     });
   };
+
+  that.recover = function() {
+    spawn_failed = false;
+    fillNodes();
+  };
   
   that.dropAllNodes = function(quietly) {
       spawn_failed = true;


### PR DESCRIPTION
We had the following scenario today:
```
2021-05-11 21:41:08.630  - INFO: ClusterWorker - Lost connection with cluster owt-cluster
2021-05-11 21:41:09.540  - WARN: AmqpClient - Late rpc reply: { data: 'whoareyou', corrID: 49019, type: 'callback' }
2021-05-11 21:41:09.541  - WARN: AmqpClient - Late rpc reply: { data: 'whoareyou', corrID: 49020, type: 'callback' }
2021-05-11 21:41:09.541  - WARN: AmqpClient - Late rpc reply: { data: 'whoareyou', corrID: 49021, type: 'callback' }
2021-05-11 21:41:09.541  - WARN: AmqpClient - Late rpc reply: { data: 'whoareyou', corrID: 49022, type: 'callback' }
2021-05-11 21:41:09.541  - WARN: AmqpClient - Late rpc reply: { data: 'whoareyou', corrID: 49023, type: 'callback' }
2021-05-11 21:41:09.541  - INFO: WorkingAgent - webrtc agent lost.
2021-05-11 21:41:09.542  - INFO: ClusterWorker - Rejoin cluster owt-cluster OK.
2021-05-11 21:41:09.542  - INFO: WorkingAgent - webrtc agent recovered.
2021-05-12 04:54:48.023  - ERROR: NodeManager - getNode error: No available node
2021-05-12 04:54:50.977  - ERROR: NodeManager - getNode error: No available node
2021-05-12 04:54:51.401  - ERROR: NodeManager - getNode error: No available node
```

After looking at the code, we have noticed that after an `agent lost` all nodes are getting dropped via the `dropAllNodes` function. This function also sets `spawn_failed` to true.

But after a `agent recovered` the `spawn_failed` variable remains true and there are no new idle nodes started.

This PR resolves this by setting `spawn_failed` back to false and running `fillNodes`.

Before merging #997 this issue was not as visible as its now, because of the missing `return` in the `pickInIdle` function. So it had still started new idle nodes every time the `No available node` error occured.