### PR TITLE
Correctly recover agent on first attempt after a loss

### DIFF
--- a/source/common/clusterWorker.js
+++ b/source/common/clusterWorker.js
@@ -155,6 +155,7 @@ module.exports = function (spec) {
                             log.info('Unknown by cluster manager', cluster_name);
                             tryRecovery(function () {
                                 log.info('Rejoin cluster', cluster_name, 'OK.');
+                                on_recovery(id);
                             });
                         }
                     }


### PR DESCRIPTION
We had a loss of the video agent which never recovered. Here are the logs:
```
2021-06-02 03:34:43.523  - INFO: ClusterWorker - Unknown by cluster manager owt-cluster
2021-06-02 03:34:43.568  - INFO: WorkingAgent - video agent lost.
2021-06-02 03:34:43.569  - INFO: ClusterWorker - Rejoin cluster owt-cluster OK.
2021-06-03 07:56:53.538  - ERROR: NodeManager - getNode error: No available node
2021-06-03 07:57:03.328  - ERROR: NodeManager - getNode error: No available node
2021-06-03 07:57:08.875  - ERROR: NodeManager - getNode error: No available node
2021-06-03 07:57:09.472  - ERROR: NodeManager - getNode error: No available node
2021-06-03 07:57:14.972  - ERROR: NodeManager - getNode error: No available node
2021-06-03 07:57:18.193  - ERROR: NodeManager - getNode error: No available node
```

After some investigation I found out that the on_recovery was not called after a successful rejoin attempt.