### PR TITLE
Fix msdk check failed when packing

### DIFF
--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -403,6 +403,7 @@ function getAddonLibs(addonPath) {
   env['LD_LIBRARY_PATH'] = path.join(depsDir, 'lib') +
     ':' + path.join(rootDir, 'third_party/openh264') +
     ':' + path.join(rootDir, 'third_party/quic-lib/dist/lib') +
+    ':' + '/opt/intel/mediasdk/lib64' + 
     ':' + env['LD_LIBRARY_PATH'];
 
   return exec(`ldd ${addonPath} | grep '=>' | awk '{print $3}' | sort | uniq | grep -v "^("`, { env })


### PR DESCRIPTION
ERROR: library dependency not found for
  /root/owt-server-5.0/dist/video_agent/videoTranscoder_msdk/build/Release/videoTranscoder-msdk.node:
	libopenh264.so.4 => not found
	libmfx.so.1 => not found
	libavutil.so.56 => not found
	libavcodec.so.58 => not found
	libavformat.so.58 => not found
	libavfilter.so.7 => not found
Something failed to build. Try nvm use v8.15.0 and rerun build.js. 

这里有个错误.