### PR TITLE
Check readable data after ondata handler is assigned.

### DIFF
--- a/source/agent/addons/quic/QuicTransportStream.cc
+++ b/source/agent/addons/quic/QuicTransportStream.cc
@@ -122,6 +122,7 @@ NAN_MODULE_INIT(QuicTransportStream::init)
     Nan::SetPrototypeMethod(tpl, "write", write);
     Nan::SetPrototypeMethod(tpl, "readTrackId", readTrackId);
     Nan::SetPrototypeMethod(tpl, "addDestination", addDestination);
+    Nan::SetPrototypeMethod(tpl, "checkReadableData", checkReadableData);
     Nan::SetAccessor(instanceTpl, Nan::New("isMedia").ToLocalChecked(), isMediaGetter, isMediaSetter);
 
     s_constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
@@ -201,6 +202,14 @@ NAN_METHOD(QuicTransportStream::removeDestination)
 NAN_METHOD(QuicTransportStream::readTrackId){
     QuicTransportStream* obj = Nan::ObjectWrap::Unwrap<QuicTransportStream>(info.Holder());
     obj->ReadTrackId();
+}
+
+NAN_METHOD(QuicTransportStream::checkReadableData)
+{
+    QuicTransportStream* obj = Nan::ObjectWrap::Unwrap<QuicTransportStream>(info.Holder());
+    if (obj->m_stream->ReadableBytes() > 0) {
+        obj->SignalOnData();
+    }
 }
 
 NAN_GETTER(QuicTransportStream::isMediaGetter){

--- a/source/agent/addons/quic/QuicTransportStream.h
+++ b/source/agent/addons/quic/QuicTransportStream.h
@@ -39,6 +39,8 @@ public:
     // Read 128 bits after content session ID. Only media streams have track ID. Result will be returned by onData callback.
     // TODO: Make this as an async method when it's supported.
     static NAN_METHOD(readTrackId);
+    // Check whether there is readable data. If so, fire ondata event.
+    static NAN_METHOD(checkReadableData);
 
     static NAN_GETTER(isMediaGetter);
     static NAN_SETTER(isMediaSetter);

--- a/source/agent/addons/quic/QuicTransportStream.h
+++ b/source/agent/addons/quic/QuicTransportStream.h
@@ -39,11 +39,11 @@ public:
     // Read 128 bits after content session ID. Only media streams have track ID. Result will be returned by onData callback.
     // TODO: Make this as an async method when it's supported.
     static NAN_METHOD(readTrackId);
-    // Check whether there is readable data. If so, fire ondata event.
-    static NAN_METHOD(checkReadableData);
 
     static NAN_GETTER(isMediaGetter);
     static NAN_SETTER(isMediaSetter);
+    static NAN_GETTER(onDataGetter);
+    static NAN_SETTER(onDataSetter);
 
     static NAUV_WORK_CB(onContentSessionId);
     static NAUV_WORK_CB(onTrackId);
@@ -80,6 +80,8 @@ private:
     void ReadTrackId();
     void SignalOnData();
     void ReallocateBuffer(size_t size);
+    // Check whether there is readable data. If so, fire ondata event.
+    void CheckReadableData();
     void AddedDestination();
     void RemovedDestination();
 
@@ -98,6 +100,7 @@ private:
 
     // Indicates whether this is a media stream. If this is not a media stream, it can only be piped to another QUIC agent.
     bool m_isMedia;
+    Nan::Persistent<v8::Value> m_onDataCallback;
 
     size_t m_readingFrameSize;
     size_t m_frameSizeOffset;

--- a/source/agent/quic/webtransport/quicTransportServer.js
+++ b/source/agent/quic/webtransport/quicTransportServer.js
@@ -152,8 +152,6 @@ module.exports = class QuicTransportServer extends EventEmitter {
             return;
           }
         };
-        // In case data arrived before ondata handler is assigned.
-        stream.checkReadableData();
       }
     }
   }

--- a/source/agent/quic/webtransport/quicTransportServer.js
+++ b/source/agent/quic/webtransport/quicTransportServer.js
@@ -151,7 +151,9 @@ module.exports = class QuicTransportServer extends EventEmitter {
             }
             return;
           }
-        }
+        };
+        // In case data arrived before ondata handler is assigned.
+        stream.checkReadableData();
       }
     }
   }


### PR DESCRIPTION
If signaling data is arrived before ondata handler is assigned, it will
not fire ondata again since OnCanRead is not called when readable queue
is not empty.

Ref: #1053.