### PR TITLE
Remove av_read_play which already called inside rtsp

### DIFF
--- a/source/core/owt_base/LiveStreamIn.cpp
+++ b/source/core/owt_base/LiveStreamIn.cpp
@@ -741,7 +741,9 @@ bool LiveStreamIn::connect()
 
     m_AsyncEvent << "}";
 
-    av_read_play(m_context);
+    if (m_context->iformat->read_play == nullptr) {
+        av_read_play(m_context);
+    }
 
     if (m_videoJitterBuffer) {
         m_videoJitterBuffer->start();
@@ -851,7 +853,9 @@ bool LiveStreamIn::reconnect()
     if (m_isFileInput)
         m_timstampOffset = m_lastTimstamp + 1;
 
-    av_read_play(m_context);
+    if (m_context->iformat->read_play == nullptr) {
+        av_read_play(m_context);
+    }
 
     if (m_videoJitterBuffer)
         m_videoJitterBuffer->start();


### PR DESCRIPTION
Some rtsp server will handle the second PLAY request
as error and disconnect the TCP connection, it will
cause the stream disconnect and trigger the reconnect
mechnism in LiveStream, continue to disconnect and
reconnect.

Signed-off-by: Yu, Dingfeng <dingfeng.yu@intel.com>