### PR TITLE
Fix WebTransport E2E test failures.

### DIFF
--- a/source/agent/addons/quic/QuicTransportConnection.h
+++ b/source/agent/addons/quic/QuicTransportConnection.h
@@ -47,6 +47,7 @@ protected:
     void OnIncomingStream(owt::quic::WebTransportStreamInterface*) override;
     void OnCanCreateNewOutgoingStream(bool unidirectional) override { }
     void OnConnectionClosed() override { }
+    void OnDatagramReceived(const uint8_t* data, size_t length) override { }
 
     // Overrides QuicTransportStream::Visitor.
     void onEnded() override;

--- a/source/agent/addons/quic/quic_sdk_url
+++ b/source/agent/addons/quic/quic_sdk_url
@@ -1,1 +1,1 @@
-https://api.github.com/repos/open-webrtc-toolkit/owt-sdk-quic/actions/artifacts/114967253/zip
+https://api.github.com/repos/open-webrtc-toolkit/owt-sdk-quic/actions/artifacts/123705465/zip

--- a/source/agent/quic/e2e-test/js/webtransport.js
+++ b/source/agent/quic/e2e-test/js/webtransport.js
@@ -6,6 +6,14 @@
 
 const expect = chai.expect;
 
+// Convert certificate fingerprint string to WebTransport certificate hash.
+const convertFingerprintToHash = (fingerprint) => {
+  const values = fingerprint.split(':');
+  return Uint8Array.from(values, x => {
+    return parseInt(x, 16);
+  });
+};
+
 describe('WebTransport end to end tests.', function() {
   it('Write an array and check data received.', (done) => {
     // Prepare data.
@@ -32,8 +40,13 @@ describe('WebTransport end to end tests.', function() {
     createToken(undefined, 'user', 'presenter', async (token) => {
       const conference = new Owt.Conference.ConferenceClient({
         webTransportConfiguration: {
-          serverCertificateFingerprints:
-              [{value: __karma__.config.cert_fingerprint, algorithm: 'sha-256'}]
+          serverCertificateFingerprints: [
+            {value: __karma__.config.cert_fingerprint, algorithm: 'sha-256'}
+          ],
+          serverCertificateHashes: [{
+            value: convertFingerprintToHash(__karma__.config.cert_fingerprint),
+            algorithm: 'sha-256'
+          }],
         }
       });
       let resolveSubscribed;


### PR DESCRIPTION
This change overrides a pure virtual function with empty implementation. This function will be implemented in another change for datagram support. It also uses `serverCertificateHashes` instead of `serverCertificateFingerprints` because of API change. 