### PR TITLE
Add a configuration file for Dependabot.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 scripts/ @starwarfan @qwu16
 docker/ @qwu16
 source/agent/addons @starwarfan
+source/agent/addons/quic @jianjunz
 source/agent/analytics @qwu16
 source/agent/audio @daijh @starwarfan
 source/agent/conference @starwarfan @qwu16

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
It avoids Dependabot to creates too many PRs. Security updates are not affected.