### PR TITLE
Enable sending media data over WebTransport streams.

### DIFF
--- a/source/agent/addons/quic/WebTransportFrameDestination.cc
+++ b/source/agent/addons/quic/WebTransportFrameDestination.cc
@@ -17,8 +17,12 @@ DEFINE_LOGGER(WebTransportFrameDestination, "WebTransportFrameDestination");
 
 Nan::Persistent<v8::Function> WebTransportFrameDestination::s_constructor;
 
-WebTransportFrameDestination::WebTransportFrameDestination()
-    : m_datagramOutput(nullptr)
+const std::string audioTrackId = "00000000000000000000000000000001";
+const std::string videoTrackId = "00000000000000000000000000000002";
+
+WebTransportFrameDestination::WebTransportFrameDestination(const std::string& subscriptionId, bool isDatagram)
+    : m_isDatagram(isDatagram)
+    , m_datagramOutput(nullptr)
     , m_rtpFactory(nullptr)
     , m_videoRtpPacketizer(nullptr)
 {
@@ -38,6 +42,8 @@ NAN_MODULE_INIT(WebTransportFrameDestination::init)
 
     Nan::SetPrototypeMethod(tpl, "addDatagramOutput", addDatagramOutput);
     Nan::SetPrototypeMethod(tpl, "removeDatagramOutput", removeDatagramOutput);
+    Nan::SetPrototypeMethod(tpl, "addStreamOutput", addStreamOutput);
+    Nan::SetPrototypeMethod(tpl, "removeStreamOutput", removeStreamOutput);
     Nan::SetPrototypeMethod(tpl, "receiver", receiver);
     Nan::SetAccessor(instanceTpl, Nan::New("rtpConfig").ToLocalChecked(), rtpConfigGetter);
 
@@ -51,7 +57,13 @@ NAN_METHOD(WebTransportFrameDestination::newInstance)
         ELOG_DEBUG("Not construct call.");
         return;
     }
-    WebTransportFrameDestination* obj = new WebTransportFrameDestination();
+    if (info.Length() < 2) {
+        return Nan::ThrowTypeError("No enough arguments are provided.");
+    }
+    Nan::Utf8String param0(Nan::To<v8::String>(info[0]).ToLocalChecked());
+    std::string subscriptionId = std::string(*param0);
+    bool isDatagram = Nan::To<bool>(info[1]).FromJust();
+    WebTransportFrameDestination* obj = new WebTransportFrameDestination(subscriptionId, isDatagram);
     obj->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
 }
@@ -87,6 +99,44 @@ NAN_METHOD(WebTransportFrameDestination::removeDatagramOutput)
     obj->m_datagramOutput = nullptr;
 }
 
+NAN_METHOD(WebTransportFrameDestination::addStreamOutput)
+{
+    if (info.Length() < 2) {
+        return Nan::ThrowTypeError("No enough arguments are provided.");
+    }
+    WebTransportFrameDestination* obj = Nan::ObjectWrap::Unwrap<WebTransportFrameDestination>(info.Holder());
+    std::unique_lock<std::shared_timed_mutex> lock(obj->m_streamOutputMutex);
+    Nan::Utf8String param0(Nan::To<v8::String>(info[0]).ToLocalChecked());
+    std::string track = std::string(*param0);
+    NanFrameNode* output = Nan::ObjectWrap::Unwrap<NanFrameNode>(Nan::To<v8::Object>(info[1]).ToLocalChecked());
+    if (obj->m_streamOutput.find(track) != obj->m_streamOutput.end()) {
+        ELOG_WARN("Stream output for track %s exists, will be replaced by the new one.", track);
+        obj->m_streamOutput[track]->FrameDestination()->setDataSource(nullptr);
+    }
+    // TODO: Use addDataDestination defined in MediaFramePipeline. We use m_streamOutput here because the output could also be datagrams.
+    obj->m_streamOutput[track] = output;
+    output->FrameDestination()->setDataSource(obj);
+    ELOG_DEBUG("Add stream output.");
+}
+
+NAN_METHOD(WebTransportFrameDestination::removeStreamOutput)
+{
+    if (info.Length() < 1) {
+        return Nan::ThrowTypeError("No enough arguments are provided.");
+    }
+    WebTransportFrameDestination* obj = Nan::ObjectWrap::Unwrap<WebTransportFrameDestination>(info.Holder());
+    std::unique_lock<std::shared_timed_mutex> lock(obj->m_streamOutputMutex);
+    Nan::Utf8String param0(Nan::To<v8::String>(info[0]).ToLocalChecked());
+    std::string track = std::string(*param0);
+    if (obj->m_streamOutput.find(track) == obj->m_streamOutput.end()) {
+        ELOG_WARN("Stream output for track %s does not exist.", track);
+        return;
+    }
+    obj->m_streamOutput[track]->FrameDestination()->setDataSource(nullptr);
+    obj->m_streamOutput.erase(track);
+    ELOG_DEBUG("Remove stream output.");
+}
+
 NAN_METHOD(WebTransportFrameDestination::receiver)
 {
     info.GetReturnValue().Set(info.This());
@@ -111,10 +161,11 @@ void WebTransportFrameDestination::onFrame(const owt_base::Frame& frame)
 {
     // Packetize video frames or send RTP packets.
     if (frame.format != owt_base::FRAME_FORMAT_RTP) {
-        if (!m_videoRtpPacketizer) {
-            return;
+        if (m_isDatagram && m_videoRtpPacketizer) {
+            m_videoRtpPacketizer->onFrame(frame);
+        } else if (!m_isDatagram) {
+            DispatchMediaFrame(frame);
         }
-        m_videoRtpPacketizer->onFrame(frame);
     } else {
         std::shared_lock<std::shared_timed_mutex> lock(m_datagramOutputMutex, std::defer_lock);
         if (!m_datagramOutput) {
@@ -135,4 +186,40 @@ void WebTransportFrameDestination::onFeedback(const owt_base::FeedbackMsg& feedb
         return;
     }
     m_videoRtpPacketizer->onFeedback(feedback);
+}
+
+void WebTransportFrameDestination::DispatchMediaFrame(const owt_base::Frame& frame)
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_streamOutputMutex);
+    owt_base::FrameDestination* dest(nullptr);
+    if (owt_base::isAudioFrame(frame)) {
+        if (m_streamOutput.find(audioTrackId) == m_streamOutput.end()) {
+            ELOG_DEBUG("Audio output not found. Dropping an audio frame.");
+            return;
+        }
+        dest = m_streamOutput[audioTrackId]->FrameDestination();
+    } else if (owt_base::isVideoFrame(frame)) {
+        if (m_streamOutput.find(videoTrackId) == m_streamOutput.end()) {
+            ELOG_DEBUG("Video output not found. Dropping a video frame.");
+            return;
+        }
+        dest = m_streamOutput[videoTrackId]->FrameDestination();
+    } else {
+        ELOG_ERROR("Unknown frame type.");
+        return;
+    }
+    // Write header. 4 bytes for the size of the body.
+    uint32_t payloadSize(frame.length);
+    uint8_t* buffer = new uint8_t[4];
+    for (int i = 0; i < 4; i++) {
+        buffer[3 - i] = payloadSize & 0xFF;
+        payloadSize >>= 8;
+    }
+    owt_base::Frame header;
+    header.format = owt_base::FRAME_FORMAT_DATA;
+    header.length = 4;
+    header.payload = buffer;
+    dest->onFrame(header);
+    // Write body.
+    dest->onFrame(frame);
 }

--- a/source/agent/addons/quic/WebTransportFrameDestination.h
+++ b/source/agent/addons/quic/WebTransportFrameDestination.h
@@ -10,6 +10,7 @@
 #include "RtpFactory.h"
 #include "owt/quic/web_transport_stream_interface.h"
 #include <shared_mutex>
+#include <unordered_map>
 #include <logger.h>
 #include <nan.h>
 
@@ -18,7 +19,7 @@ class WebTransportFrameDestination : public owt_base::FrameSource, public owt_ba
     DECLARE_LOGGER();
 
 public:
-    explicit WebTransportFrameDestination();
+    explicit WebTransportFrameDestination(const std::string& subscriptionId, bool isDatagram);
     ~WebTransportFrameDestination() override = default;
 
     static NAN_MODULE_INIT(init);
@@ -39,13 +40,23 @@ private:
     static NAN_METHOD(newInstance);
     static NAN_METHOD(addDatagramOutput);
     static NAN_METHOD(removeDatagramOutput);
+    // addStreamOutput(string:trackId, WebTransportStream:stream).
+    static NAN_METHOD(addStreamOutput);
+    // removeStreamOutput(string:trackId).
+    static NAN_METHOD(removeStreamOutput);
     // receiver() is required by connection.js.
     static NAN_METHOD(receiver);
     // Returns an object of RTP configuration. {audio:{ssrc}, video:{ssrc}}. Returns undefined if no RTP receiver is available.
     static NAN_GETTER(rtpConfigGetter);
 
+    // Dispatch a media frame to its corresponding WebTransport stream. It works for WebTransport streams only.
+    void DispatchMediaFrame(const owt_base::Frame&);
+
+    bool m_isDatagram;
     std::shared_timed_mutex m_datagramOutputMutex;
     NanFrameNode* m_datagramOutput;
+    std::shared_timed_mutex m_streamOutputMutex;
+    std::unordered_map<std::string, NanFrameNode*> m_streamOutput; // Key is track ID.
     std::unique_ptr<RtpFactoryBase> m_rtpFactory;
     std::unique_ptr<VideoRtpPacketizerInterface> m_videoRtpPacketizer;
 };

--- a/source/agent/quic/agent.toml
+++ b/source/agent/quic/agent.toml
@@ -48,6 +48,9 @@ minport = 0 #default: 0
 
 #########################################################################################
 [quic]
+# Sending media data over WebTransport stream or datagram. Default value is 'datagram'. This is an experimental feature for performance comparison. It will be moved to client's request.
+mediaOutMode = "datagram"
+
 # Key store path doesn't work right now.
 keystorePath = "./cert/certificate.pfx"
 

--- a/source/agent/quic/webtransport/quicTransportServer.js
+++ b/source/agent/quic/webtransport/quicTransportServer.js
@@ -27,9 +27,11 @@ module.exports = class QuicTransportServer extends EventEmitter {
     super();
     this._server = new addon.QuicTransportServer(port, pfxPath, password);
     this._connections = new Map(); // Key is transport ID.
-    this._streams = new Map(); // Key is content session ID.
+    // Key is content session ID + track ID.
+    // TODO: Remove stream from this map when the session is end.
+    this._streams = new Map();
     this._unAuthenticatedConnections = []; // When it's authenticated, it will be moved to this.connections.
-    this._unAssociatedStreams = []; // No content session ID assgined to them.
+    this._unAssociatedStreams = []; // No content session ID assigned to them.
     this._validateTokenCallback = validateTokenCallback;
     this._server.onconnection = (connection) => {
       this._unAuthenticatedConnections.push(connection);
@@ -172,10 +174,10 @@ module.exports = class QuicTransportServer extends EventEmitter {
 
   // Create a send stream for specfied QuicTransport. If specified QuicTransport
   // doesn't exist, no stream will be created.
-  createSendStream(transportId, contentSessionId) {
+  createSendStream(transportId, contentSessionId, trackId) {
     log.debug(
         'Create send stream ' + contentSessionId + ' on transport ' +
-        transportId);
+        transportId + ', track ID: ' + trackId);
     if (!this._connections.has(transportId)) {
       // TODO: Waiting for transport to be created, and create stream for it.
       // It's a common case that subscribe request is received by QUIC agent
@@ -184,9 +186,13 @@ module.exports = class QuicTransportServer extends EventEmitter {
       return;
     }
     const stream = this._connections.get(transportId).createBidirectionalStream();
-    const uuidBytes=this._uuidStringToUint8Array(contentSessionId);
+    let uuidBytes = this._uuidStringToUint8Array(contentSessionId);
     stream.write(uuidBytes, uuidBytes.length);
-    this._streams.set(contentSessionId, stream);
+    this._streams.set(contentSessionId + trackId, stream);
+    if (trackId) {
+      uuidBytes = this._uuidStringToUint8Array(trackId);
+      stream.write(uuidBytes, uuidBytes.length);
+    }
     return stream;
   }
 


### PR DESCRIPTION
Unlike media data over datagrams, this change allows sending media data
in a reliable way for some special cases that packet drop is not
acceptable.