### PR TITLE
Bump zlib from 1.2.11 to 1.2.12.

### DIFF
--- a/scripts/installCommonDeps.sh
+++ b/scripts/installCommonDeps.sh
@@ -95,7 +95,7 @@ install_ffmpeg(){
 }
 
 install_zlib() {
-  local VERSION="1.2.11"
+  local VERSION="1.2.12"
 
   local LIST_LIBS=`ls ${PREFIX_DIR}/lib/libz* 2>/dev/null`
   [ "$INCR_INSTALL" = true ]  && [[ ! -z $LIST_LIBS ]] && \


### PR DESCRIPTION
The download link for 1.2.11 is unavailable.

Fixes #1189.