### PR TITLE
Check return value of WebTransport stream write.

### DIFF
--- a/source/agent/addons/quic/QuicTransportStream.cc
+++ b/source/agent/addons/quic/QuicTransportStream.cc
@@ -467,7 +467,12 @@ void QuicTransportStream::onFeedback(const owt_base::FeedbackMsg&)
 
 void QuicTransportStream::onFrame(const owt_base::Frame& frame)
 {
-    m_stream->Write(frame.payload, frame.length);
+    size_t wrote = m_stream->Write(frame.payload, frame.length);
+    if (wrote != frame.length) {
+        // TODO: Implement back pressure.
+        // https://github.com/open-webrtc-toolkit/owt-server/issues/1220
+        ELOG_WARN("Failed to write a frame. This frame is dropped.");
+    }
 }
 
 void QuicTransportStream::onVideoSourceChanged()


### PR DESCRIPTION
QUIC agent cannot decide how to deal with the data if sending queue is
full as it doesn't understand the meaning of the data.