### PR TITLE
Av1x changed to AV1 and chrome100+ subscription AV1 failed due to payload…

### DIFF
--- a/source/agent/conference/conference.js
+++ b/source/agent/conference/conference.js
@@ -60,7 +60,7 @@ const {
    *    }
    *
    *    object(VideoFormat):: {
-   *      codec: 'h264' | 'vp8' | 'h265' | 'vp9' | 'av1x',
+   *      codec: 'h264' | 'vp8' | 'h265' | 'vp9' | 'av1',
    *      profile: 'constrained-baseline' | 'baseline' | 'main' | 'high' | undefined
    *    }
    *

--- a/source/agent/video/videoCapability.js
+++ b/source/agent/video/videoCapability.js
@@ -22,8 +22,8 @@ module.exports.detected = (requireHWAcc) => {
   var useHW = false;
   // TODO: support av1x.
   var codecs = {
-    decode: ['vp8', 'vp9', 'h264', 'h265','av1'],
-    encode: ['vp8', 'vp9','av1']
+    decode: ['vp8', 'vp9', 'h264', 'h265', 'av1'],
+    encode: ['vp8', 'vp9', 'av1']
   };
   
   if (requireHWAcc && isHWAccAppliable()) {

--- a/source/agent/video/videoCapability.js
+++ b/source/agent/video/videoCapability.js
@@ -22,8 +22,8 @@ module.exports.detected = (requireHWAcc) => {
   var useHW = false;
   // TODO: support av1x.
   var codecs = {
-    decode: ['vp8', 'vp9', 'h264', 'h265','av1','av1x'],
-    encode: ['vp8', 'vp9','av1' ,'av1x']
+    decode: ['vp8', 'vp9', 'h264', 'h265','av1'],
+    encode: ['vp8', 'vp9','av1']
   };
   
   if (requireHWAcc && isHWAccAppliable()) {

--- a/source/agent/webrtc/mediaConfig.js
+++ b/source/agent/webrtc/mediaConfig.js
@@ -94,6 +94,20 @@ const h265 = {
   ],
 };
 
+const av1 = {
+  payloadType: 35,
+  encodingName: 'AV1',
+  clockRate: 90000,
+  channels: 1,
+  mediaType: 'video',
+  feedbackTypes: [
+    'ccm fir',
+    'nack',
+    'transport-cc',
+    'goog-remb',
+  ],
+};
+
 const red = {
   payloadType: 116,
   encodingName: 'red',
@@ -219,7 +233,7 @@ const telephoneevent = {
 const mediaConfig = {
   default: {
     rtpMappings: {
-      vp8, vp9, h264, h265, red, rtx,
+      vp8, vp9, h264, h265,av1, red, rtx,
       opus, pcmu, pcma, isac16, isac32, g722, ilbc,
       ulpfec, telephoneevent
     },

--- a/source/agent/webrtc/mediaConfig.js
+++ b/source/agent/webrtc/mediaConfig.js
@@ -233,7 +233,7 @@ const telephoneevent = {
 const mediaConfig = {
   default: {
     rtpMappings: {
-      vp8, vp9, h264, h265,av1, red, rtx,
+      vp8, vp9, h264, h265, av1, red, rtx,
       opus, pcmu, pcma, isac16, isac32, g722, ilbc,
       ulpfec, telephoneevent
     },

--- a/source/core/owt_base/MediaFramePipeline.h
+++ b/source/core/owt_base/MediaFramePipeline.h
@@ -107,7 +107,7 @@ inline FrameFormat getFormat(const std::string& codec) {
         return owt_base::FRAME_FORMAT_VP9;
     } else if (codec == "h265") {
         return owt_base::FRAME_FORMAT_H265;
-    } else if (codec == "av1x") {
+    } else if (codec == "av1") {
         return owt_base::FRAME_FORMAT_AV1;
     } else if (codec == "pcm_48000_2" || codec == "pcm_raw") {
         return owt_base::FRAME_FORMAT_PCM_48000_2;

--- a/source/management_console/public/js/App.js
+++ b/source/management_console/public/js/App.js
@@ -605,7 +605,6 @@ class RoomModal extends React.Component {
       'vp8': {codec: 'vp8'},
       'vp9': {codec: 'vp9'},
       'av1': {codec: 'av1'}, //for chrome95+
-      'av1x': {codec: 'av1x'},
       // audio
       'opus': {codec: 'opus', sampleRate: 48000, channelNum: 2},
       'isac-16000': {codec: 'isac', sampleRate: 16000},
@@ -704,7 +703,7 @@ class RoomModal extends React.Component {
       return mediaCheckBox(name, 'mediaIn.audio');
     });
 
-    const videoNames = ['h264', 'h265', 'vp8', 'vp9','av1','av1x'];
+    const videoNames = ['h264', 'h265', 'vp8', 'vp9','av1'];
     const videoCheckBoxes = videoNames.map((name) => {
       return mediaCheckBox(name, 'mediaIn.video');
     });
@@ -750,7 +749,7 @@ class RoomModal extends React.Component {
       'h264-baseline',
       'h264-main',
       'h264-high',
-      'h265', 'vp8', 'vp9', 'av1x',
+      'h265', 'vp8', 'vp9', 'av1',
     ];
     const videoCheckBoxes = videoNames.map((name) => {
       return mediaCheckBox(name, 'mediaOut.video.format');


### PR DESCRIPTION
Av1x in the standard has been changed to AV1, which is recommended to be modified.
The change of AV1 payload type of chrome100+ leads to the failure of subscribing to AV1 during forward stream. mediaConfig.js add parameters of AV1

https://bugs.chromium.org/p/webrtc/issues/detail?id=13166
https://aomediacodec.github.io/av1-rtp-spec/