### PR TITLE
fix amqpClient.js not handle close event.

### DIFF
--- a/source/common/amqpClient.js
+++ b/source/common/amqpClient.js
@@ -534,6 +534,7 @@ class AmqpCli {
     amqp.connect(this.options).then((conn) => {
       log.debug('Connect OK');
       conn.on('error', this._errorHandler);
+      conn.on('close',this._errorHandler);
       this.connection = conn;
       return conn.createChannel();
     })


### PR DESCRIPTION
rabbitmq重启,这里漏了close事件的处理.