### PR TITLE
Run WebTransport tests on Ubuntu 20.04.

### DIFF
--- a/.github/workflows/webtransport.yaml
+++ b/.github/workflows/webtransport.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   ci:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     services:
       rabbitmq:
           image: rabbitmq:latest

--- a/scripts/installDeps.sh
+++ b/scripts/installDeps.sh
@@ -130,7 +130,9 @@ then
   if [[ "$OS_VERSION" =~ 20.04.* ]]
   then
     install_gcc_7
-    install_boost
+    if [ "$GITHUB_ACTIONS" != "true" ]; then
+      install_boost
+    fi
   fi
 fi
 

--- a/scripts/installDepsUnattended.sh
+++ b/scripts/installDepsUnattended.sh
@@ -94,7 +94,9 @@ then
     if [[ "$OS_VERSION" =~ 20.04.* ]]
     then
       install_gcc_7
-      install_boost
+      if [ "$GITHUB_ACTIONS" != "true" ]; then
+        install_boost
+      fi
     fi
   fi
 fi

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -12,7 +12,7 @@ install_apt_deps(){
     if [ -d $LIB_DIR ]; then
       echo "Installing mongodb-org from tar"
       ${SUDO} apt-get install -y libcurl4 openssl liblzma5
-      wget -P $LIB_DIR https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.4.6.tgz
+      wget -q -P $LIB_DIR https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.4.6.tgz
       tar -zxvf $LIB_DIR/mongodb-linux-x86_64-ubuntu1804-4.4.6.tgz -C $LIB_DIR
       ${SUDO} ln -s $LIB_DIR/mongodb-linux-x86_64-ubuntu1804-4.4.6/bin/* /usr/local/bin/
     else

--- a/source/core/owt_base/internal/TransportClient.cpp
+++ b/source/core/owt_base/internal/TransportClient.cpp
@@ -44,8 +44,7 @@ bool TransportClient::enableSecure()
     ELOG_DEBUG("Client enable secure");
     m_isSecure = true;
 
-    m_sslContext.reset(new boost::asio::ssl::context(
-                    m_service->service(), boost::asio::ssl::context::sslv23));
+    m_sslContext.reset(new boost::asio::ssl::context(boost::asio::ssl::context::sslv23));
     m_sslContext->set_verify_mode(boost::asio::ssl::context::verify_peer);
     m_sslContext->use_certificate_file(kServerCrt, boost::asio::ssl::context::pem);
     m_sslContext->set_password_callback(boost::bind(&TransportSecret::getPassphrase));

--- a/source/core/owt_base/internal/TransportServer.cpp
+++ b/source/core/owt_base/internal/TransportServer.cpp
@@ -52,8 +52,7 @@ bool TransportServer::enableSecure()
     ELOG_DEBUG("Server enable secure");
     m_isSecure = true;
 
-    m_sslContext.reset(new boost::asio::ssl::context(
-        m_service->service(), boost::asio::ssl::context::sslv23));
+    m_sslContext.reset(new boost::asio::ssl::context(boost::asio::ssl::context::sslv23));
     m_sslContext->set_options(
         boost::asio::ssl::context::default_workarounds
         | boost::asio::ssl::context::single_dh_use);


### PR DESCRIPTION
Fix #1246.

Apt installs a newer version of boost for Ubuntu 20.04. This change also removes the use of deprecated boost APIs for internal IO so an old version of boost is not needed for WebTransport tests.