### PR TITLE
zlib version update 1.2.13  

### DIFF
--- a/scripts/installCommonDeps.sh
+++ b/scripts/installCommonDeps.sh
@@ -95,7 +95,7 @@ install_ffmpeg(){
 }
 
 install_zlib() {
-  local VERSION="1.2.12"
+  local VERSION="1.2.13"
 
   local LIST_LIBS=`ls ${PREFIX_DIR}/lib/libz* 2>/dev/null`
   [ "$INCR_INSTALL" = true ]  && [[ ! -z $LIST_LIBS ]] && \


### PR DESCRIPTION
The download link "https://zlib.net/zlib-1.2.12.tar.gz" is invalid