### PR TITLE
Portal upgrade socket.io from 3.1.2 to 4.5.0 ;  Manage-Console upgrade express from 4.16.4 to 4.17.3

### DIFF
--- a/source/management_console/package.json
+++ b/source/management_console/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.0",
   "dependencies": {
     "bootstrap": "^3.3.1",
-    "express": "4.16.4",
+    "express": "4.17.3",
     "express-session": "^1.17.1",
     "http-proxy": "1.18.1",
     "jquery": "^3.0.0",

--- a/source/portal/package.json
+++ b/source/portal/package.json
@@ -3,7 +3,7 @@
   "version":"5.0.0",
   "dependencies": {
     "amqplib": "^0.7.0",
-    "socket.io": "^3.1.1",
+    "socket.io": "^4.5.0",
     "log4js": "*",
     "toml": "*",
     "sprintf-js": "^1.0.3",


### PR DESCRIPTION
OWT-MCU-Portal upgrade socket.io from 3.1.2 to 4.5.0
OWT-MCU-Manage-Console upgrade express from 4.16.4 to 4.17.3