### PR TITLE
Run WebTransport E2E test with Python 3.10

### DIFF
--- a/.github/workflows/webtransport.yaml
+++ b/.github/workflows/webtransport.yaml
@@ -23,7 +23,7 @@ jobs:
           node-version: "14"
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - run: npm install
         name: Install dependencies for JavaScript SDK
         working-directory: third_party/owt-client-javascript/scripts


### PR DESCRIPTION
It looks like some dependencies don't work with Python 3.11.