### PR TITLE
deep clone data before notify to clients

### DIFF
--- a/source/portal/socketIOServer.js
+++ b/source/portal/socketIOServer.js
@@ -487,7 +487,8 @@ var SocketIOServer = function(spec, portal, observer) {
     log.debug('receivers:', JSON.stringify(receivers));
     for (let clientId of receivers) {
       if (!excludeList.includes(clientId) && clients[clientId]) {
-        clients[clientId].notify(event, data);
+        let dataClone = JSON.parse(JSON.stringify(data));
+        clients[clientId].notify(event, dataClone);
       }
     }
   }


### PR DESCRIPTION
If different client version (eg: v1.2,v1.1)  in one room ,the converted data was incorrectly sent to the v1.2 client. So make a deep copy before the message is sent , to prevent the data reference changing by portalDataAdapter in other client session.