### PR TITLE
add raft to select leader and upgrade the amqpClient to support recreate queue、exchange、reconnect

### DIFF
--- a/source/agent/nodeManager.js
+++ b/source/agent/nodeManager.js
@@ -8,6 +8,7 @@ var fs = require('fs');
 var spawn = require('child_process').spawn;
 var logger = require('./logger').logger;
 var log = logger.getLogger('NodeManager');
+const util = require('util');
 
 var enableGRPC = false;
 

--- a/source/cluster_manager/clusterManager.js
+++ b/source/cluster_manager/clusterManager.js
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 'use strict';
+const util = require('util');
 var logger = require('./logger').logger;
 var Scheduler = require('./scheduler').Scheduler;
 
 // Logger
 var log = logger.getLogger('ClusterManager');
-var role = null;
 var Url = require("url");
 
 var ClusterManager = function (clusterName, selfId, spec) {

--- a/source/cluster_manager/clusterManager.js
+++ b/source/cluster_manager/clusterManager.js
@@ -744,8 +744,8 @@ var runAsLeader = function (topicChannel, manager) {
 
         interval && clearInterval(interval);
         manager.unserve();
-        await topicChannel.bus.removeRpcServer();
         await topicChannel.unsubscribe(routerKeys);
+        await topicChannel.bus.removeRpcServer();
         log.info('leader->candidate');
         await runAsCandidate(topicChannel, manager);
     });

--- a/source/cluster_manager/clusterManager.js
+++ b/source/cluster_manager/clusterManager.js
@@ -828,11 +828,11 @@ var runAsLeader = function (topicChannel, manager) {
                     log.info('Cluster leader is in service as leader!');
                     leaderMsgHandler = onTopicMessage;
                     manager.registerDataUpdate(function (data) {
-                        state.prevLogIndex = state.commitId;
-                        state.prevLogTerm = state.term;
                         state.commitId++;
                         data = Object.assign({data}, state);
                         topicChannel.publish('clusterManager.broadcast', {type: 'appendEntry', data: data});
+                        state.prevLogIndex = state.commitId;
+                        state.prevLogTerm = state.term;
                     });
                     log.info('Run as leader success id:',manager.id);
                     observer.resetTimer();

--- a/source/cluster_manager/clusterManager.js
+++ b/source/cluster_manager/clusterManager.js
@@ -915,7 +915,7 @@ var runAsCandidate = function (topicChannel, manager) {
             }
 
             //vote for self
-            if(data.id == manager.id && state.lastVoteTerm == data.term){
+            if(data.id == manager.id && state.term == data.term){
                 log.warn("vote for yourself",  "self:", state);
                 state.lastVoteTerm = data.term;
                 state.lastVoteFor = manager.id;
@@ -931,7 +931,6 @@ var runAsCandidate = function (topicChannel, manager) {
                 responseVote(data.term, data.id, data.commitId);
                 return;
             }
-
 
             responseVote( state.term, manager.id, state.commitId);
             // only left the candidate to vote,it means many node found leader is loss

--- a/source/cluster_manager/cluster_manager.toml
+++ b/source/cluster_manager/cluster_manager.toml
@@ -4,6 +4,7 @@ port = 5672 #default: 5672
 
 [manager]
 name = "owt-cluster"
+totalNode = 1
 
 #The time for cluster manager getting ready to handle the incoming 'schedule' requirements.
 initial_time = 6000 #ms
@@ -12,7 +13,7 @@ initial_time = 6000 #ms
 check_alive_interval = 1000 #ms
 
 #The threshold count of consecutive absences after which the corresponding cluster workers will be deleted.
-check_alive_count = 3
+check_alive_count = 86400
 
 #The default reservation time if not specified in the scheduling requirement.
 schedule_reserve_time = 60000 #ms

--- a/source/cluster_manager/index.js
+++ b/source/cluster_manager/index.js
@@ -53,9 +53,10 @@ function startup () {
         initialTime: config.manager.initial_time,
         checkAlivePeriod: config.manager.check_alive_interval,
         checkAliveCount: config.manager.check_alive_count,
-        scheduleKeepTime: config.manager.schedule_reserve_time,
+        scheduleReserveTime: config.manager.schedule_reserve_time,//keycoding 20230811:fix schedule_reserve_time no used in clusterManager
         strategy: config.strategy,
-        enableCascading: config.cascading.enabled, url: config.cascading.url, region: config.cascading.region, clusterID: config.cascading.clusterID
+        enableCascading: config.cascading.enabled, url: config.cascading.url, region: config.cascading.region, clusterID: config.cascading.clusterID,
+        totalNode: config.manager.totalNode ? config.manager.totalNode : 1 //keycoding 20230811: totalNode for raft to elect leader
     };
 
     if (config.manager.enable_grpc) {

--- a/source/cluster_manager/index.js
+++ b/source/cluster_manager/index.js
@@ -10,6 +10,8 @@ var log = logger.getLogger('Main');
 var ClusterManager = require('./clusterManager');
 var toml = require('toml');
 var fs = require('fs');
+var util = require('util');
+
 var config;
 var clusterManager;
 try {
@@ -53,10 +55,10 @@ function startup () {
         initialTime: config.manager.initial_time,
         checkAlivePeriod: config.manager.check_alive_interval,
         checkAliveCount: config.manager.check_alive_count,
-        scheduleReserveTime: config.manager.schedule_reserve_time,//keycoding 20230811:fix schedule_reserve_time no used in clusterManager
+        scheduleReserveTime: config.manager.schedule_reserve_time,
         strategy: config.strategy,
         enableCascading: config.cascading.enabled, url: config.cascading.url, region: config.cascading.region, clusterID: config.cascading.clusterID,
-        totalNode: config.manager.totalNode ? config.manager.totalNode : 1 //keycoding 20230811: totalNode for raft to elect leader
+        totalNode: config.manager.totalNode ? config.manager.totalNode : 1
     };
 
     if (config.manager.enable_grpc) {
@@ -87,7 +89,7 @@ function startup () {
             clusterManager = new ClusterManager.manager(channel, config.manager.name, id, spec);
             clusterManager.run(channel);
         }, function(reason) {
-            log.error('Cluster manager initializing failed, reason:', reason);
+            log.error('Cluster manager initializing failed, reason:', reason && reason.message ? reason.message : util.inspect(reason));
             process.kill(process.pid, 'SIGINT');
         });
     };
@@ -95,7 +97,7 @@ function startup () {
     amqper.connect(config.rabbit, function () {
         enableService();
     }, function(reason) {
-        log.error('Cluster manager connect to rabbitMQ server failed, reason:', reason);
+        log.error('Cluster manager connect to rabbitMQ server failed, reason:', reason && reason.message ? reason.message : util.inspect(reason));
         process.kill(process.pid, 'SIGINT');
     });
 }

--- a/source/cluster_manager/scheduler.js
+++ b/source/cluster_manager/scheduler.js
@@ -188,7 +188,11 @@ exports.Scheduler = function(spec) {
     };
 
     that.getScheduled = function (task, on_ok, on_error) {
-        tasks[task] ? on_ok(tasks[task].worker) : on_error('No such a task');
+        /**
+         * keycoding 20230811
+         * 1、modify the error msg,let the clusterWork get the real error
+         */
+        tasks[task] ? on_ok(tasks[task].worker) : on_error(`NO_SUCH_TASK:${task}`);
     };
 
     that.setScheduled = function (task, worker, reserveTime) {
@@ -211,6 +215,10 @@ exports.Scheduler = function(spec) {
             tasks[task] = data.tasks[task];
         }
     };
+
+    that.isWorkerAvailable = function(worker){
+        return isWorkerAvailable(workers[worker]);
+    }
 
     that.serve = function () {
         for (var task in tasks) {

--- a/source/common/amqpClient.js
+++ b/source/common/amqpClient.js
@@ -765,10 +765,8 @@ class AmqpCli {
 
     this.successCb.push(onOk);
     this.failureCb.push(onFailure);
-
-    options.storePath = options.storePath || cipher.astore;
-    if (fs.existsSync(options.storePath)) {
-      cipher.unlock(cipher.k, options.storePath, (err, authConfig) => {
+    if (fs.existsSync(cipher.astore)) {
+      cipher.unlock(cipher.k, cipher.astore, (err, authConfig) => {
         if (!err) {
           if (authConfig.rabbit) {
             this.options.username = authConfig.rabbit.username;


### PR DESCRIPTION
1. add raft to select leader
2. fix workingNode recycle will tigger coredump
3. let the agent to recever to the new leader and pickUpTasks
4. amqpClient support mutil rabbitmq host
5. amqpClient support recreate the queue or recreate the exchange which was deleted
6. support reconnect to the rabbitmq and auto choice the available host