### PR TITLE
fix wrong truncation of DB_URL

### DIFF
--- a/source/management_api/init.sh
+++ b/source/management_api/init.sh
@@ -43,7 +43,7 @@ shopt -s extglob
 while [[ $# -gt 0 ]]; do
   case $1 in
     *(-)dburl=* )
-      DB_URL=$(echo $1 | cut -d '=' -f 2)
+      DB_URL=$(echo $1 | cut -d '=' -f 2-)
       echo -e "\x1b[36musing $DB_URL\x1b[0m"
       ;;
     *(-)help )


### PR DESCRIPTION
``` bash
MONGO=mongodb+srv://owt:qwer4321Tig@mongodb-svc.default.svc.cluster.local/owt?replicaSet=mongodb&ssl=false
echo dburl=$MONGO | cut -d '=' -f 2
# output mongodb+srv://owt:qwer4321Tig@mongodb-svc.default.svc.cluster.local/owt?replicaSet
echo dburl=$MONGO | cut -d '=' -f 2-
# output mongodb+srv://owt:qwer4321Tig@mongodb-svc.default.svc.cluster.local/owt?replicaSet=mongodb&ssl=false
```
Without this pr, if I send the argument dburl with a mongo connect string with parameters to shell management-api/init.sh, the connect string is truncated and become a illegal mongo connect string.