### PR TITLE
fix grpc missing host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules/
 *.d
 *.a
 *.so
+.vscode

--- a/source/agent/index.js
+++ b/source/agent/index.js
@@ -87,6 +87,7 @@ var joinCluster = function (on_ok) {
         rpcClient: rpcClient,
         purpose: myPurpose,
         clusterName: config.cluster.name,
+        clusterHost: config.cluster.host,
         joinRetry: config.cluster.worker.join_retry,
         // Cannot find a defination about |info|. It looks like it will be used by cluster manager, but agents and portal may have different properties of |info|.
         info: {

--- a/source/event_bridge/index.js
+++ b/source/event_bridge/index.js
@@ -100,6 +100,7 @@ var joinCluster = function (on_ok) {
   var spec = {rpcClient: rpcClient,
               purpose: 'eventbridge',
               clusterName: config.cluster.name,
+              clusterHost: config.cluster.host,
               joinRetry: config.cluster.join_retry,
               info: {ip: config.bridge.hostname || ip_address,
                      port: config.bridge.port,

--- a/source/management_api/requestHandler.js
+++ b/source/management_api/requestHandler.js
@@ -35,7 +35,7 @@ var e = require('./errors');
 
 const enableGrpc = global.config?.server?.enable_grpc || false;
 if (enableGrpc) {
-  cluster_name = global.config?.cluster?.grpc_host || 'localhost:10080';
+  cluster_name = global.config?.cluster?.host || global.config?.cluster?.grpc_host || 'localhost:10080';
 }
 
 const scheduleAgent = function(agentName, tokenCode, origin, attempts, callback) {

--- a/source/portal/index.js
+++ b/source/portal/index.js
@@ -139,6 +139,7 @@ var joinCluster = function (on_ok) {
   var spec = {rpcClient: rpcClient,
               purpose: 'portal',
               clusterName: config.cluster.name,
+              clusterHost: config.cluster.host,
               joinRetry: config.cluster.join_retry,
               info: {
                 ip: ip_address,


### PR DESCRIPTION
When enable grpc, owt always use default cluster host even I config the cluster.host according document.
This pr fix it.

By the way, according document, to enable grpc, we should add host.cluster to components except cluster-manager. But according to the source code, cluster.grpc_host is required, too. Is any difference between cluster.host and cluster.grpc_host?