### PR TITLE
Initialize config.cascading in cluster_manager

### DIFF
--- a/source/cluster_manager/index.js
+++ b/source/cluster_manager/index.js
@@ -42,6 +42,7 @@ config.rabbit = config.rabbit || {};
 config.rabbit.host = config.rabbit.host || 'localhost';
 config.rabbit.port = config.rabbit.port || 5672;
 
+config.cascading = config.cascading || {};
 config.cascading.enabled = config.cascading.enabled || false;
 config.cascading.url = config.cascading.url;
 config.cascading.region = config.cascading.region;


### PR DESCRIPTION
The other config fields are initialized, this one not which raises errors if the agents toml doesn't include the cascading section.
