### PR TITLE
optimize and add leader lease for raft

### DIFF
--- a/source/cluster_manager/clusterManager.js
+++ b/source/cluster_manager/clusterManager.js
@@ -970,7 +970,7 @@ var runAsFollower = function(topicChannel, manager) {
                     if (state.lastVoteFor == data.id) {
                         responseVote(state.term, data.id, state.commitIndex, data.term, true);
                         return
-                    } else if (!(state.lastVoteFor == state.id && state.prevLogIndex == DEFAULT_DATA && data.prevLogIndex != DEFAULT_DATA)) {
+                    } else if (!(state.lastVoteFor == state.id && state.prevLogIndex < data.prevLogIndex)) {
                         responseVote(state.term, data.id, state.commitIndex, data.term, false);
                         return
                     }
@@ -1356,7 +1356,7 @@ var runAsCandidate = function(topicChannel, manager) {
                     if (state.lastVoteFor == data.id) {
                         responseVote(state.term, data.id, state.commitIndex, data.term, true);
                         return
-                    } else if (!(state.lastVoteFor == state.id && state.prevLogIndex == DEFAULT_DATA && data.prevLogIndex != DEFAULT_DATA)) {
+                    } else if (!(state.lastVoteFor == state.id && state.prevLogIndex < data.prevLogIndex)) {
                         responseVote(state.term, data.id, state.commitIndex, data.term, false);
                         return
                     }

--- a/source/cluster_manager/cluster_manager.toml
+++ b/source/cluster_manager/cluster_manager.toml
@@ -6,8 +6,15 @@ port = 5672 #default: 5672
 name = "owt-cluster"
 #Set its value to the number of cluster manager instances，suggest odd number
 totalNode = 1 #node become leader when got vote gt totalNode/2
-# elect leader timeout
+
+#electTimeout specifies the time in candidate state without contact from a leader before we attempt an election.
 electTimeout = 1000 #ms
+
+#leaderLeaseTimeout is used to control how long the "lease" lasts for being the leader without being able to contact a quorum of nodes. If we reach this interval without contact, we will step down as leader.
+leaderLeaseTimeout = 500 #ms
+
+#heartbeatTimeout specifies the time in follower state without contact from a leader before we attempt an election.
+heartbeatTimeout = 1000 #ms
 
 #The time for cluster manager getting ready to handle the incoming 'schedule' requirements.
 initial_time = 6000 #ms

--- a/source/cluster_manager/index.js
+++ b/source/cluster_manager/index.js
@@ -27,6 +27,24 @@ config.manager.check_alive_count = config.manager.check_alive_count || 10;
 config.manager.schedule_reserve_time = config.manager.schedule_reserve_time || 60 * 1000;
 config.manager.totalNode = config.manager.totalNode || 1;
 config.manager.electTimeout = config.manager.electTimeout || 1000;
+if (config.manager.electTimeout < 1000) {
+    log.error(`electTimeout is too low it must egt 1000ms`);
+    process.exit(1);
+}
+if(!config.manager.heartbeatTimeout){
+    config.manager.heartbeatTimeout = config.manager.electTimeout;
+}
+if(!config.manager.leaderLeaseTimeout){
+    config.manager.leaderLeaseTimeout = parseInt(config.manager.heartbeatTimeout/2);
+}
+if (config.manager.heartbeatTimeout < 1000) {
+    log.error(`heartbeatTimeout is too low it must egt 1000ms`);
+    process.exit(1);
+}
+if (config.manager.leaderLeaseTimeout < 500) {
+    log.error(`leaderLeaseTimeout is too low it must egt 500ms`);
+    process.exit(1);
+}
 
 config.strategy = config.strategy || {};
 config.strategy.general = config.strategy.general || 'round-robin';
@@ -60,7 +78,9 @@ function startup () {
         strategy: config.strategy,
         enableCascading: config.cascading.enabled, url: config.cascading.url, region: config.cascading.region, clusterID: config.cascading.clusterID,
         totalNode:config.manager.totalNode,
-        electTimeout:config.manager.electTimeout
+        electTimeout:config.manager.electTimeout,
+        heartbeatTimeout: config.manager.heartbeatTimeout,
+        leaderLeaseTimeout: config.manager.leaderLeaseTimeout
     };
 
     if (config.manager.enable_grpc) {


### PR DESCRIPTION
1. change variable name commitId to commitIndex
2. enable heartbeatTime and leaderLeaseTimeout configurations not to be calculated through electTimeout, but to support independent configuration
3. optimize preLogTerm compare, by comparing the preLogIndex of the requesting voting node with its own preLogIndex to obtain preLogTerm, instead of using state. preLogTerm fixed, we can improves the speed of voting
5. optimize the voting decision for candidates. candidates within the same term are first voted for by oneself. When receiving voting requests from other nodes within the same term, if one is still in a candidate state and their data is outdated, their votes will be transferred to other nodes improves the speed of voting
6. optimize installsnapshot so that it can only be successfully issued once during concurrent execution of installsnapshot, and under the control of installSnapshotMutex, other queued requests entering the installsnapshot method are automatically canceled to determine if their request is outdated
7. add responseHeartbeat for follower when it receive heartbeat from leader
8. add a leader lease mechanism, where the leader determines whether more than half of the nodes are unresponsive by judging whether they have received a follower response, thereby actively transitioning to a follower state, avoiding the problem of dual leaders in network partitioning